### PR TITLE
Feature save colorbuffer jpg

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
@@ -196,6 +196,14 @@ enum class MagnifyingFilter {
     LINEAR
 }
 
+/**
+ * File format used while saving to file
+ */
+enum class FileFormat {
+    JPG,
+    PNG,
+}
+
 interface BufferWriter {
     fun write(vararg v: Vector3) {
         v.forEach { write(it) }
@@ -252,7 +260,7 @@ interface ColorBuffer {
     val effectiveHeight: Int get() = (height * contentScale).toInt()
 
 
-    fun saveToFile(file: File)
+    fun saveToFile(file: File, fileFormat: FileFormat = FileFormat.PNG)
     fun destroy()
     fun bind(unit: Int)
 

--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
@@ -260,7 +260,15 @@ interface ColorBuffer {
     val effectiveHeight: Int get() = (height * contentScale).toInt()
 
 
-    fun saveToFile(file: File, fileFormat: FileFormat = FileFormat.PNG)
+    fun saveToFile(file: File, fileFormat: FileFormat = guessFromExtension(file))
+    private fun guessFromExtension(file: File): FileFormat {
+        return when {
+            file.name.toLowerCase().endsWith("jpg") -> FileFormat.JPG
+            file.name.toLowerCase().endsWith("jpeg") -> FileFormat.JPG
+            else -> FileFormat.PNG
+        }
+    }
+
     fun destroy()
     fun bind(unit: Int)
 

--- a/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/ColorBufferGL3.kt
+++ b/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/ColorBufferGL3.kt
@@ -463,9 +463,9 @@ class ColorBufferGL3(val target: Int,
         }
     }
 
-    override fun saveToFile(file: File) {
+    override fun saveToFile(file: File, fileFormat: FileFormat) {
         if (type == ColorType.UINT8) {
-            val pixels = BufferUtils.createByteBuffer(effectiveWidth * effectiveHeight * format.componentCount)
+            var pixels = BufferUtils.createByteBuffer(effectiveWidth * effectiveHeight * format.componentCount)
             (pixels as Buffer).rewind()
             read(pixels)
             (pixels as Buffer).rewind()
@@ -481,9 +481,18 @@ class ColorBufferGL3(val target: Int,
                     flippedPixels.put(row)
                 }
                 (flippedPixels as Buffer).rewind()
-                STBImageWrite.stbi_write_png(file.absolutePath, effectiveWidth, effectiveHeight, format.componentCount, flippedPixels, effectiveWidth * format.componentCount)
-            } else {
-                STBImageWrite.stbi_write_png(file.absolutePath, effectiveWidth, effectiveHeight, format.componentCount, pixels, effectiveWidth * format.componentCount)
+                pixels = flippedPixels
+            }
+
+            when (fileFormat) {
+                FileFormat.JPG -> STBImageWrite.stbi_write_jpg(
+                        file.absolutePath,
+                        effectiveWidth, effectiveHeight,
+                        format.componentCount, pixels, 90)
+                FileFormat.PNG -> STBImageWrite.stbi_write_png(
+                        file.absolutePath,
+                        effectiveWidth, effectiveHeight,
+                        format.componentCount, pixels, effectiveWidth * format.componentCount)
             }
         } else {
             TODO("support non-UINT8 types")


### PR DESCRIPTION
When saving a `ColorBuffer` and the chosen file name ends with `jpg` or `jpeg`, the file format used is JPG, in all other cases the file is saved as PNG.

The user can always override the guessing behavior by passing the `FileFormat` enum manually as second parameter to `saveToFile`.