### PR TITLE
Update gradle wrapper distributionUrl to 4.10-all

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
Gradle 4.6 fails to find valid installs of JDK for Java 11,  resulting in the following error message in IntelliJ console:

    Could not determine java version from '11'.

This PR resolves the issue by updating Gradle to 4.10.

Further details on this Gradle 4.6 issue can be found at https://github.com/gradle/gradle/issues/4591, https://github.com/gradle/gradle/issues/4515 and https://github.com/bladecoder/bladecoder-adventure-engine/issues/39.