### PR TITLE
API-doc: adds KDoc Module and Package info

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -1,12 +1,11 @@
 # Module openrndr
+## OPENRNDR Standard Library
 A Kotlin/JVM library for creative coding, real-time and interactive graphics. Can currently be used on Windows, macOS and Linux/x64 to create stand alone graphical applications.
 
-## Additional Resources
-Please have a look at our [application template](https://github.com/openrndr/openrndr-gradle-template) and our [tutorial repository](https://github.com/openrndr/openrndr-tutorials) for usage examples.
-
-Basics and use are further explained in the [OPENRNDR guide](https://guide.openrndr.org) and more project information can be found on our [website](https://openrndr.org) 
-
-The OPENRNDR source is hosted on [Github](https://github.com/openrndr/openrndr)
+Additional Resources:
+- Please have a look at our [application template](https://github.com/openrndr/openrndr-gradle-template) and our [tutorial repository](https://github.com/openrndr/openrndr-tutorials) for usage examples.
+- Basics and use are further explained in the [OPENRNDR guide](https://guide.openrndr.org) and more project information can be found on our [website](https://openrndr.org) 
+- The OPENRNDR source is hosted on [Github](https://github.com/openrndr/openrndr)
 
 
 # Package org.openrndr
@@ -14,6 +13,9 @@ the core of OPENRNDR
 
 # Package org.openrndr.animatable
 optional animation library
+
+## 
+A tool to create interactive animations. 
 
 # Package org.openrndr.animatable.easing
 [easing](https://easings.net) types specify the rate of change of a parameter over time.

--- a/Module.md
+++ b/Module.md
@@ -1,0 +1,94 @@
+# Module openrndr
+A Kotlin/JVM library for creative coding, real-time and interactive graphics. Can currently be used on Windows, macOS and Linux/x64 to create stand alone graphical applications.
+
+## Additional Resources
+Please have a look at our [application template](https://github.com/openrndr/openrndr-gradle-template) and our [tutorial repository](https://github.com/openrndr/openrndr-tutorials) for usage examples.
+
+Basics and use are further explained in the [OPENRNDR guide](https://guide.openrndr.org) and more project information can be found on our [website](https://openrndr.org) 
+
+The OPENRNDR source is hosted on [Github](https://github.com/openrndr/openrndr)
+
+
+# Package org.openrndr
+the core of OPENRNDR
+
+# Package org.openrndr.animatable
+optional animation library
+
+# Package org.openrndr.animatable.easing
+[easing](https://easings.net) types specify the rate of change of a parameter over time.
+
+# Package org.openrndr.binpack
+a binpacker, used internally for creating texture atlases.
+
+# Package org.openrndr.color
+code related to working with Color
+
+# Package org.openrndr.draw
+a core component related to Drawing
+
+# Package org.openrndr.events
+a simple event library
+
+# Package org.openrndr.extensions
+a simple Extension interface with which default Program behaviour can be changed.
+
+# Package org.openrndr.ffmpeg
+code related to optional FFMPEG based video playback
+
+# Package org.openrndr.filter
+optional library of filtering and post processing related code
+
+# Package org.openrndr.filter.antialias
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.blend
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.blur
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.color
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.dither
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.screenspace
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.transforms
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.filter.unary
+a filter type in the openrndr-filter library
+
+# Package org.openrndr.internal
+a core component
+
+# Package org.openrndr.internal.gl3
+the OpenGL3 backend for OPENGL
+
+# Package org.openrndr.internal.gl3.dds
+support for dds file format
+
+# Package org.openrndr.math
+code related to math, mostly computer graphics math
+
+# Package org.openrndr.math.transforms
+code related to math transformations
+
+# Package org.openrndr.platform
+a core component related to platforms
+
+# Package org.openrndr.shadestyle
+code related to Shade styles
+
+# Package org.openrndr.shape
+code related to 2d shapes
+
+# Package org.openrndr.svg
+code related to reading and writing SVG files
+
+# Package org.openrndr.text
+a core component related to working with Text

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dokka {
     moduleName = "$rootProject.name"
     outputDirectory = "$buildDir/docs"
     outputFormat = "html"
-
+    includes = ['Module.md']
+    
     sourceDirs = files(subprojects.collect { p -> new File(p.projectDir, "/src/main/kotlin") })
     if (!System.properties['os.name'].toLowerCase().contains('windows')) {
 


### PR DESCRIPTION
This is a recce PR.

It populates the landing page of the API-doc. It's just a first pass - these one-liner summaries leave a lot to be desired. Succinct one liner summaries require expert knowledge - so a second-pass by the right person could update these in a few minutes, especially since they are contained within a single markdown file.

The change is low-risk since no `.kt` source files were changed. But I set a property in the`build.gradle` file, so at least the first build should be monitored. I have unit-tested this locally.   