### PR TITLE
Use URL for name on font

### DIFF
--- a/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/FontImageMapManagerGL3.kt
+++ b/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/FontImageMapManagerGL3.kt
@@ -167,7 +167,7 @@ class FontImageMapManagerGL3 : FontMapManager() {
         image.write(bitmap)
 
         val leading = ascent - descent + lineGap
-        return FontImageMap(image, map, glyphMetrics, size, contentScale, ascent / contentScale, descent / contentScale, (ascent + descent) / contentScale, leading / contentScale, "test")
+        return FontImageMap(image, map, glyphMetrics, size, contentScale, ascent / contentScale, descent / contentScale, (ascent + descent) / contentScale, leading / contentScale, url)
     }
 }
 


### PR DESCRIPTION
Use `url` as name on font instead of "test"