### PR TITLE
Add geometry selection to Filter: Triangle or Quad

### DIFF
--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/antialias/FXAA.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/antialias/FXAA.kt
@@ -4,7 +4,7 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class FXAA : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("antialias/fxaa.frag"))) {
+class FXAA : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("antialias/fxaa.frag"))) {
 
     var lumaThreshold: Double by parameters
     var maxSpan: Double by parameters

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/blend/BlendFilters.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/blend/BlendFilters.kt
@@ -4,27 +4,27 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class ColorBurn : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/color-burn.frag")))
-class ColorDodge : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/color-dodge.frag")))
-class Darken : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/darken.frag")))
-class HardLight : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/hard-light.frag")))
-class Lighten : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/lighten.frag")))
-class Multiply : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/multiply.frag")))
-class Normal : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/normal.frag")))
-class Overlay : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/overlay.frag")))
-class Screen : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/screen.frag")))
+class ColorBurn : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/color-burn.frag")))
+class ColorDodge : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/color-dodge.frag")))
+class Darken : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/darken.frag")))
+class HardLight : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/hard-light.frag")))
+class Lighten : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/lighten.frag")))
+class Multiply : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/multiply.frag")))
+class Normal : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/normal.frag")))
+class Overlay : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/overlay.frag")))
+class Screen : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/screen.frag")))
 
-class SourceIn : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/source-in.frag")))
-class SourceOut : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/source-out.frag")))
-class DestinationIn : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/destination-in.frag")))
-class DestinationOut : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/destination-out.frag")))
-class Xor : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/xor.frag")))
+class SourceIn : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/source-in.frag")))
+class SourceOut : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/source-out.frag")))
+class DestinationIn : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/destination-in.frag")))
+class DestinationOut : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/destination-out.frag")))
+class Xor : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/xor.frag")))
 
-class MultiplyContrast : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/multiply-contrast.frag")))
+class MultiplyContrast : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/multiply-contrast.frag")))
 
-class Passthrough : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/passthrough.frag")))
-class Add : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/add.frag")))
-class Subtract : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("blend/subtract.frag")))
+class Passthrough : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/passthrough.frag")))
+class Add : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/add.frag")))
+class Subtract : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("blend/subtract.frag")))
 
 val multiply: Multiply by lazy { Multiply().apply { untrack() } }
 val passthrough: Passthrough by lazy { Passthrough().apply { untrack() } }

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/ApproximateGaussianBlur.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/ApproximateGaussianBlur.kt
@@ -7,7 +7,7 @@ import org.openrndr.draw.colorBuffer
 import org.openrndr.filter.filterFragmentCode
 import org.openrndr.math.Vector2
 
-class ApproximateGaussianBlur : Filter(Shader.createFromCode(Filter.filterVertexCode,
+class ApproximateGaussianBlur : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode,
         filterFragmentCode("blur/approximate-gaussian-blur.frag"))) {
 
     var window: Int by parameters

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/BoxBlur.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/BoxBlur.kt
@@ -7,7 +7,7 @@ import org.openrndr.draw.colorBuffer
 import org.openrndr.filter.filterFragmentCode
 import org.openrndr.math.Vector2
 
-class BoxBlur : Filter(Shader.createFromCode(Filter.filterVertexCode,
+class BoxBlur : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode,
         filterFragmentCode("blur/box-blur.frag"))) {
 
     var window: Int by parameters

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/GaussianBlur.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/GaussianBlur.kt
@@ -4,7 +4,7 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class GaussianBlur : Filter(Shader.createFromCode(Filter.filterVertexCode,
+class GaussianBlur : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode,
         filterFragmentCode("blur/gaussian-blur.frag"))) {
 
     var window: Int by parameters
@@ -18,6 +18,4 @@ class GaussianBlur : Filter(Shader.createFromCode(Filter.filterVertexCode,
         sigma = 1.0
         gain = 1.0
     }
-
-
 }

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/HashBlur.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/blur/HashBlur.kt
@@ -4,7 +4,7 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class HashBlur : Filter(Shader.createFromCode(Filter.filterVertexCode,
+class HashBlur : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode,
         filterFragmentCode("blur/hash-blur.frag"))) {
 
     var radius:Double by parameters

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/color/ColorFilters.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/color/ColorFilters.kt
@@ -3,12 +3,12 @@ package org.openrndr.filter.color
 import org.openrndr.draw.*
 import org.openrndr.filter.filterFragmentCode
 
-class Linearize : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("color/linearize.frag")))
-class Delinearize : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("color/delinearize.frag")))
-class ColorMix : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("color/color-mix.frag")))
-class HybridLogGamma : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("color/hybrid-log-gamma.frag")))
+class Linearize : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("color/linearize.frag")))
+class Delinearize : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("color/delinearize.frag")))
+class ColorMix : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("color/color-mix.frag")))
+class HybridLogGamma : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("color/hybrid-log-gamma.frag")))
 
-class ColorLookup(lookup: ColorBuffer) : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("color/color-lookup.frag"))) {
+class ColorLookup(lookup: ColorBuffer) : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("color/color-lookup.frag"))) {
     var lookup: ColorBuffer by parameters
     var noiseGain: Double by parameters
     var seed: Double by parameters

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/dither/ADither.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/dither/ADither.kt
@@ -4,7 +4,7 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class ADither: Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("dither/a-dither.frag"))) {
+class ADither: Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("dither/a-dither.frag"))) {
     var pattern: Int
         set(value) {
             parameters["pattern"] = value

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/transform/Transforms.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/transform/Transforms.kt
@@ -4,6 +4,6 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class FlipVertically : Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("transform/flip-vertically.frag")))
+class FlipVertically : Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("transform/flip-vertically.frag")))
 
 val flipVertically: FlipVertically by lazy { FlipVertically().apply { untrack() } }

--- a/openrndr-filter/src/main/kotlin/org/openrndr/filter/unary/UnaryFilters.kt
+++ b/openrndr-filter/src/main/kotlin/org/openrndr/filter/unary/UnaryFilters.kt
@@ -5,7 +5,7 @@ import org.openrndr.draw.Filter
 import org.openrndr.draw.Shader
 import org.openrndr.filter.filterFragmentCode
 
-class SubtractConstant: Filter(Shader.createFromCode(Filter.filterVertexCode, filterFragmentCode("unary/subtract-constant.frag"))) {
+class SubtractConstant: Filter(Shader.createFromCode(Filter.filterTriangleVertexCode, filterFragmentCode("unary/subtract-constant.frag"))) {
 
     var constant:ColorRGBa by parameters
     init {

--- a/openrndr-filter/src/main/resources/org/openrndr/filter/gl3/blur/gaussian-blur.frag
+++ b/openrndr-filter/src/main/resources/org/openrndr/filter/gl3/blur/gaussian-blur.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 330
 
 in vec2 v_texCoord0;
 uniform sampler2D tex0;

--- a/openrndr-filter/src/main/resources/org/openrndr/filter/gl3/blur/hash-blur.frag
+++ b/openrndr-filter/src/main/resources/org/openrndr/filter/gl3/blur/hash-blur.frag
@@ -16,7 +16,7 @@ out vec4 o_color;
 
 //-------------------------------------------------------------------------------------------
 // Use last part of hash function to generate new random radius and angle...
-vec2 sample(inout vec2 r) {
+vec2 circularSampling(inout vec2 r) {
     r = fract(r * vec2(33.3983, 43.4427));
     //return r-.5;
     return sqrt(r.x+.001) * vec2(sin(r.y * TAU), cos(r.y * TAU))*.5; // <<=== circular sampling.
@@ -37,7 +37,7 @@ vec4 blur(vec2 uv, float radius) {
 
 	vec4 acc = vec4(0.0);
 	for (int i = 0; i < samples; i++) {
-		acc += texture(tex0, uv + circle * sample(random));
+		acc += texture(tex0, uv + circle * circularSampling(random));
     }
 	return acc / float(samples);
 }

--- a/openrndr-gl3/src/main/resources/org/openrndr/internal/gl3/shaders/filter-quad.vert
+++ b/openrndr-gl3/src/main/resources/org/openrndr/internal/gl3/shaders/filter-quad.vert
@@ -1,4 +1,4 @@
-// openrndr - gl3 - filter.vert
+// openrndr - gl3 - filter-quad.vert
 
 #version 330
 

--- a/openrndr-gl3/src/main/resources/org/openrndr/internal/gl3/shaders/filter-triangle.vert
+++ b/openrndr-gl3/src/main/resources/org/openrndr/internal/gl3/shaders/filter-triangle.vert
@@ -1,0 +1,12 @@
+// openrndr - gl3 - filter-triangle.vert
+
+#version 330
+
+in vec2 a_position;
+
+out vec2 v_texCoord0;
+
+void main() {
+    v_texCoord0 = a_position * 0.5 + 0.5;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+}


### PR DESCRIPTION
Based on [GCN Execution Patterns in Full Screen Passes)(https://michaldrobot.com/2014/04/01/gcn-execution-patterns-in-full-screen-passes/) and [Cat like coding](https://catlikecoding.com/unity/tutorials/scriptable-render-pipeline/post-processing/)

@edwinRNDR I'm unsure if GPUs nowadays perform optimizations for this special case and if so, whether there is a need to provide this option to the Filter.