### PR TITLE
Add strokeWeight support when drawing Composition

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
@@ -655,6 +655,13 @@ class Drawer(val driver: Driver) {
                             stroke = it.color
                         }
                     }
+
+                    compositionNode.strokeWeight.let {
+                        if (it is StrokeWeight) {
+                            strokeWeight = it.weight
+                        }
+                    }
+
                     shape(compositionNode.shape)
                 }
                 is TextNode -> TODO()


### PR DESCRIPTION
Hi!
I added a `strokeWeight` support when drawing `Composition` in the `Drawer.composition` method.