### PR TITLE
Add rgb(gray) method

### DIFF
--- a/openrndr-color/src/main/kotlin/org/openrndr/color/ColorRGBa.kt
+++ b/openrndr-color/src/main/kotlin/org/openrndr/color/ColorRGBa.kt
@@ -137,20 +137,13 @@ fun mix(left: ColorRGBa, right: ColorRGBa, x: Double): ColorRGBa {
 }
 
 /**
- * Color in RGBa space
- *
- * @param gray gray value in [0,1]
- */
-fun rgb(gray: Double) = ColorRGBa(gray, gray, gray)
-
-/**
- * Color in RGBa space
+ * Color in RGBa space. Specify one value only to obtain a shade of gray.
  *
  * @param r red in [0,1]
  * @param g green in [0,1]
  * @param b blue in [0,1]
  */
-fun rgb(r: Double, g: Double, b: Double) = ColorRGBa(r, g, b)
+fun rgb(r: Double, g: Double = r, b: Double = r) = ColorRGBa(r, g, b)
 
 /**
  * Color in RGBa space

--- a/openrndr-color/src/main/kotlin/org/openrndr/color/ColorRGBa.kt
+++ b/openrndr-color/src/main/kotlin/org/openrndr/color/ColorRGBa.kt
@@ -139,6 +139,13 @@ fun mix(left: ColorRGBa, right: ColorRGBa, x: Double): ColorRGBa {
 /**
  * Color in RGBa space
  *
+ * @param gray gray value in [0,1]
+ */
+fun rgb(gray: Double) = ColorRGBa(gray, gray, gray)
+
+/**
+ * Color in RGBa space
+ *
  * @param r red in [0,1]
  * @param g green in [0,1]
  * @param b blue in [0,1]

--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
@@ -8,6 +8,7 @@ import org.openrndr.internal.*
 import org.openrndr.math.Matrix44
 import org.openrndr.math.Vector2
 import org.openrndr.math.Vector3
+import org.openrndr.math.YPolarity
 import org.openrndr.math.transforms.rotate
 import org.openrndr.math.transforms.rotateZ
 import org.openrndr.math.transforms.scale
@@ -387,7 +388,7 @@ class Drawer(val driver: Driver) {
     }
 
     fun segment(segment: Segment) {
-        contour(ShapeContour(listOf(segment), false))
+        contour(ShapeContour(listOf(segment), false, YPolarity.CW_NEGATIVE_Y))
     }
 
     /**

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
@@ -21,9 +21,9 @@ fun derivative(x0: Vector2, c0: Vector2, x1: Vector2, t: Double): Vector2 {
 
 fun derivative(x0: Vector3, c0: Vector3, x1: Vector3, t: Double): Vector3 {
     val it = 1.0 - t
-    return Vector3(2 * it - (c0.x - x0.x) + 2 * t * (x1.x - c0.x),
-            2 * it - (c0.y - x0.y) + 2 * t * (x1.y - c0.y),
-            2 * it - (c0.z - x0.z) + 2 * t * (x1.z - c0.z)
+    return Vector3(2 * it * (c0.x - x0.x) + 2 * t * (x1.x - c0.x),
+            2 * it * (c0.y - x0.y) + 2 * t * (x1.y - c0.y),
+            2 * it * (c0.z - x0.z) + 2 * t * (x1.z - c0.z)
     )
 }
 

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
@@ -19,6 +19,28 @@ fun derivative(x0: Vector2, c0: Vector2, x1: Vector2, t: Double): Vector2 {
     return Vector2(2 * it * (c0.x - x0.x) + 2 * t * (x1.x - c0.x), 2 * it * (c0.y - x0.y) + 2 * t * (x1.y - c0.y))
 }
 
+/**
+ * like [derivative] but handles cases in which p0/p1 or p2/p3 coincide
+ */
+fun safeDerivative(p0: Vector2, c0 : Vector2, p1: Vector2, t: Double): Vector2 {
+    val epsilon = 10E-6
+    var u = t
+
+    val d10 = c0 - p0
+    val d21 = c0 - p1
+
+    if (u < epsilon && d10.squaredLength < epsilon ) {
+        u = epsilon
+    }
+
+    if (u > (1.0 - epsilon) && d21.squaredLength < epsilon) {
+        u = 1.0 - epsilon
+    }
+
+    val iu = 1.0 - u
+    return Vector2(2 * iu * (c0.x - p0.x) + 2 * u * (p1.x - c0.x), 2 * iu * (c0.y - p0.y) + 2 * u * (p1.y - c0.y))
+}
+
 fun derivative(x0: Vector3, c0: Vector3, x1: Vector3, t: Double): Vector3 {
     val it = 1.0 - t
     return Vector3(2 * it * (c0.x - x0.x) + 2 * t * (x1.x - c0.x),

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Bezier.kt
@@ -16,7 +16,7 @@ fun derivative(x0: Double, c0: Double, x1: Double, t: Double): Double {
 
 fun derivative(x0: Vector2, c0: Vector2, x1: Vector2, t: Double): Vector2 {
     val it = 1.0 - t
-    return Vector2(2 * it - (c0.x - x0.x) + 2 * t * (x1.x - c0.x), 2 * it - (c0.y - x0.y) + 2 * t * (x1.y - c0.y))
+    return Vector2(2 * it * (c0.x - x0.x) + 2 * t * (x1.x - c0.x), 2 * it * (c0.y - x0.y) + 2 * t * (x1.y - c0.y))
 }
 
 fun derivative(x0: Vector3, c0: Vector3, x1: Vector3, t: Double): Vector3 {

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Vector2.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Vector2.kt
@@ -4,6 +4,11 @@ import java.io.Serializable
 import java.lang.Math.toRadians
 import kotlin.math.*
 
+enum class YPolarity {
+    CCW_POSITIVE_Y,
+    CW_NEGATIVE_Y
+}
+
 /**
  * Double precision vector 2
  */
@@ -19,16 +24,21 @@ data class Vector2(val x: Double, val y: Double) : Serializable {
     val squaredLength: Double
         get() = x * x + y * y
 
-    val perpendicular: Vector2 get() = Vector2(-y, x)
 
-    val normalized: Vector2 get() {
-        val localLength = length
-        return if (localLength > 0.0) {
-            this / length
-        } else {
-            Vector2.ZERO
-        }
+    fun perpendicular(polarity: YPolarity = YPolarity.CW_NEGATIVE_Y): Vector2 = when (polarity) {
+        YPolarity.CCW_POSITIVE_Y -> Vector2(-y, x)
+        YPolarity.CW_NEGATIVE_Y -> Vector2(y, -x)
     }
+
+    val normalized: Vector2
+        get() {
+            val localLength = length
+            return if (localLength > 0.0) {
+                this / length
+            } else {
+                Vector2.ZERO
+            }
+        }
 
     infix fun dot(right: Vector2) = x * right.x + y * right.y
     infix fun reflect(surfaceNormal: Vector2): Vector2 = this - surfaceNormal * (this dot surfaceNormal) * 2.0

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/CompositionDrawer.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/CompositionDrawer.kt
@@ -3,6 +3,7 @@ package org.openrndr.shape
 import org.openrndr.color.ColorRGBa
 import org.openrndr.math.Matrix44
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 import org.openrndr.math.transforms.rotateZ
 import org.openrndr.math.transforms.scale
 import org.openrndr.math.transforms.transform
@@ -126,11 +127,11 @@ class CompositionDrawer {
     }
 
     fun lineStrip(points: List<Vector2>) {
-        contour(ShapeContour.fromPoints(points, false))
+        contour(ShapeContour.fromPoints(points, false, YPolarity.CW_NEGATIVE_Y))
     }
 
     fun lineLoop(points: List<Vector2>) {
-        contour(ShapeContour.fromPoints(points, true))
+        contour(ShapeContour.fromPoints(points, true, YPolarity.CW_NEGATIVE_Y))
     }
 
     fun text(text: String, position: Vector2) {

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/LineSegment.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/LineSegment.kt
@@ -3,6 +3,7 @@
 package org.openrndr.shape
 
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 import org.openrndr.math.map
 import kotlin.math.max
 import kotlin.math.min
@@ -13,7 +14,7 @@ class LineSegment(val start: Vector2, val end: Vector2) {
     constructor(x0: Double, y0: Double, x1: Double, y1: Double) : this(Vector2(x0, y0), Vector2(x1, y1))
 
     val direction get() = (end - start)
-    val normal get() = (end - start).normalized.perpendicular
+    val normal get() = (end - start).normalized.perpendicular(YPolarity.CW_NEGATIVE_Y)
 
     fun nearest(query: Vector2): Vector2 {
         val l2 = end.minus(start).squaredLength
@@ -103,7 +104,7 @@ class LineSegment(val start: Vector2, val end: Vector2) {
     fun position(t: Double) = start + (end.minus(start) * t)
 
     val contour: ShapeContour
-        get() = ShapeContour.fromPoints(listOf(start, end), false)
+        get() = ShapeContour.fromPoints(listOf(start, end), false, YPolarity.CW_NEGATIVE_Y)
 
     val shape: Shape
         get() = Shape(listOf(contour))

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/Rectangle.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/Rectangle.kt
@@ -3,6 +3,7 @@
 package org.openrndr.shape
 
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 
 data class Rectangle(val corner: Vector2, val width: Double, val height: Double) {
 
@@ -32,7 +33,7 @@ data class Rectangle(val corner: Vector2, val width: Double, val height: Double)
         get() =
             ShapeContour.fromPoints(listOf(corner, corner + Vector2(width, 0.0),
                     corner + Vector2(width, height),
-                    corner + Vector2(0.0, height)), true)
+                    corner + Vector2(0.0, height)), true, YPolarity.CW_NEGATIVE_Y)
 
     /** create a new [Rectangle] instance with offset edges */
     fun offsetEdges(offset: Double, offsetY: Double = offset): Rectangle {

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/Shape.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/Shape.kt
@@ -616,7 +616,7 @@ enum class SegmentJoin {
 data class ShapeContour(val segments: List<Segment>, val closed: Boolean, val polarity: YPolarity = YPolarity.CW_NEGATIVE_Y) {
 
     companion object {
-        fun fromPoints(points: List<Vector2>, closed: Boolean, polarity: YPolarity) =
+        fun fromPoints(points: List<Vector2>, closed: Boolean, polarity: YPolarity = YPolarity.CW_NEGATIVE_Y) =
                 if (!closed)
                     ShapeContour((0 until points.size - 1).map { Segment(points[it], points[it + 1]) }, closed, polarity)
                 else {

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/ShapeBuilder.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/ShapeBuilder.kt
@@ -1,6 +1,7 @@
 package org.openrndr.shape
 
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 import org.openrndr.math.mod_
 import kotlin.math.*
 
@@ -11,14 +12,14 @@ class ShapeBuilder {
     internal val contours = mutableListOf<ShapeContour>()
 
     fun contour(shapeContour: ShapeContour) {
-        contours.add(if (contours.size == 0) shapeContour.counterClockwise else shapeContour.clockwise)
+        contours.add(if (contours.size == 0) shapeContour.clockwise else shapeContour.counterClockwise)
     }
 
     fun contour(f: ContourBuilder.() -> Unit) {
         val cb = ContourBuilder()
         cb.f()
-        val c = ShapeContour(cb.segments, cb.closed)
-        contours.add(if (contours.size == 0) c.counterClockwise else c.clockwise)
+        val c = ShapeContour(cb.segments, cb.closed, YPolarity.CW_NEGATIVE_Y)
+        contours.add(if (contours.size == 0) c.clockwise else c.counterClockwise)
     }
 }
 
@@ -380,5 +381,5 @@ fun shape(f: ShapeBuilder.() -> Unit): Shape {
 fun contour(f: ContourBuilder.() -> Unit): ShapeContour {
     val cb = ContourBuilder()
     cb.f()
-    return ShapeContour(cb.segments, cb.closed)
+    return ShapeContour(cb.segments, cb.closed, YPolarity.CW_NEGATIVE_Y)
 }

--- a/openrndr-shape/src/main/kotlin/org/openrndr/shape/ShapeOperations.kt
+++ b/openrndr-shape/src/main/kotlin/org/openrndr/shape/ShapeOperations.kt
@@ -4,6 +4,7 @@ package org.openrndr.shape
 
 import io.lacuna.artifex.*
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 
 private fun Vector2.toVec2(): Vec2 {
     return Vec2(x, y)
@@ -70,7 +71,7 @@ private fun Curve2.toSegment(): Segment {
 }
 
 private fun Ring2.toShapeContour(): ShapeContour {
-    return ShapeContour(this.curves.map { it.toSegment() }, true)
+    return ShapeContour(this.curves.map { it.toSegment() }, true, YPolarity.CW_NEGATIVE_Y)
 }
 
 private fun List<Shape>.toRegion2(): Region2 {
@@ -197,7 +198,7 @@ fun intersection(from: List<Shape>, with: List<List<Shape>>): List<Shape> {
 fun split(shape: Shape, line: LineSegment): Pair<List<Shape>, List<Shape>> {
     val center = (line.end + line.start) / 2.0
     val direction = (line.end - line.start).normalized
-    val perpendicular = direction.perpendicular
+    val perpendicular = direction.perpendicular(shape.contours.first().polarity)
     val extend = 50000.0
 
     val splitLine = LineSegment(center - direction * extend, center + direction * extend)

--- a/openrndr-shape/src/test/kotlin/TestCircle.kt
+++ b/openrndr-shape/src/test/kotlin/TestCircle.kt
@@ -1,0 +1,23 @@
+import org.amshove.kluent.`should be equal to`
+import org.openrndr.math.YPolarity
+import org.openrndr.shape.Circle
+import org.openrndr.shape.Rectangle
+import org.openrndr.shape.Winding
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object TestCircle : Spek({
+    describe("A circle's contour") {
+        val c = Circle(200.0, 200.0, 200.0).contour
+        it("is closed") {
+            c.closed `should be equal to` true
+        }
+        it("the winding is CCW") {
+            c.winding `should be equal to` Winding.CLOCKWISE
+        }
+        it("the polarity is CW negative y") {
+            c.polarity `should be equal to` YPolarity.CW_NEGATIVE_Y
+        }
+    }
+
+})

--- a/openrndr-shape/src/test/kotlin/TestCompoundBuilder.kt
+++ b/openrndr-shape/src/test/kotlin/TestCompoundBuilder.kt
@@ -1,0 +1,85 @@
+import org.amshove.kluent.`should be equal to`
+import org.openrndr.math.YPolarity
+import org.openrndr.shape.Circle
+import org.openrndr.shape.Winding
+import org.openrndr.shape.compound
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object TestCompoundBuilder : Spek({
+    val width = 640
+    val height = 480
+    describe("a simple union compound") {
+        val sc = compound {
+            union {
+                shape(Circle(185.0, height / 2.0 - 80.0, 100.0).shape)
+                shape(Circle(185.0, height / 2.0 + 80.0, 100.0).shape)
+            }
+        }
+        it("has one shape") {
+            sc.size `should be equal to` 1
+        }
+
+        it("shape has one contour") {
+            sc[0].contours.size `should be equal to` 1
+        }
+
+        it("contour has clockwise winding") {
+            sc[0].contours[0].winding `should be equal to` Winding.CLOCKWISE
+        }
+
+        it("contour has right polarity") {
+            sc[0].contours[0].polarity `should be equal to` YPolarity.CW_NEGATIVE_Y
+        }
+    }
+
+    describe("a simple difference compound") {
+        // -- shape difference
+        val sc = compound {
+            difference {
+                shape(Circle(385.0, height / 2.0 - 80.0, 100.0).shape)
+                shape(Circle(385.0, height / 2.0 + 80.0, 100.0).shape)
+            }
+        }
+        it("has one shape") {
+            sc.size `should be equal to` 1
+        }
+
+        it("shape has one contour") {
+            sc[0].contours.size `should be equal to` 1
+        }
+
+        it("contour has clockwise winding") {
+            sc[0].contours[0].winding `should be equal to` Winding.CLOCKWISE
+        }
+
+        it("contour has right polarity") {
+            sc[0].contours[0].polarity `should be equal to` YPolarity.CW_NEGATIVE_Y
+        }
+    }
+
+    describe("a simple intersection compound") {
+        // -- shape difference
+        val sc = compound {
+            intersection {
+                shape(Circle(385.0, height / 2.0 - 80.0, 100.0).shape)
+                shape(Circle(385.0, height / 2.0 + 80.0, 100.0).shape)
+            }
+        }
+        it("has one shape") {
+            sc.size `should be equal to` 1
+        }
+
+        it("shape has one contour") {
+            sc[0].contours.size `should be equal to` 1
+        }
+
+        it("contour has clockwise winding") {
+            sc[0].contours[0].winding `should be equal to` Winding.CLOCKWISE
+        }
+
+        it("contour has right polarity") {
+            sc[0].contours[0].polarity `should be equal to` YPolarity.CW_NEGATIVE_Y
+        }
+    }
+})

--- a/openrndr-shape/src/test/kotlin/TestRectangle.kt
+++ b/openrndr-shape/src/test/kotlin/TestRectangle.kt
@@ -1,0 +1,26 @@
+import org.amshove.kluent.`should be equal to`
+import org.openrndr.math.YPolarity
+import org.openrndr.shape.Rectangle
+import org.openrndr.shape.Winding
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object TestRectangle : Spek({
+
+
+    describe("A rectangle's contour") {
+
+        val c = Rectangle(50.0,50.0, 200.0, 200.0).contour
+        it("is closed") {
+            c.closed `should be equal to` true
+        }
+        it("the winding is CCW") {
+            c.winding `should be equal to` Winding.CLOCKWISE
+        }
+
+        it("the polarity is CW negative y") {
+            c.polarity `should be equal to` YPolarity.CW_NEGATIVE_Y
+        }
+    }
+
+})

--- a/openrndr-shape/src/test/kotlin/TestSegment.kt
+++ b/openrndr-shape/src/test/kotlin/TestSegment.kt
@@ -1,7 +1,4 @@
-import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should be greater than`
-import org.amshove.kluent.`should be`
-import org.amshove.kluent.shouldBeInRange
+import org.amshove.kluent.*
 import org.openrndr.math.Vector2
 import org.openrndr.shape.Segment
 import org.spekframework.spek2.Spek
@@ -14,6 +11,12 @@ infix fun Vector2.`should be near`(other: Vector2) {
 }
 
 object TestSegment : Spek({
+
+    describe("a horizontal segment") {
+        val segment = Segment(Vector2(0.0, 100.0), Vector2(100.0, 100.0))
+        segment.normal(0.0) `should be near` Vector2(0.0, -1.0)
+    }
+
     describe("a linear segment") {
         val segment = Segment(Vector2(0.0, 0.0), Vector2(100.0, 100.0))
         it("has evaluable and correct bounds") {
@@ -22,6 +25,12 @@ object TestSegment : Spek({
             bounds.y `should be equal to` segment.start.y
             bounds.width `should be equal to` 100.0
             bounds.height `should be equal to` 100.0
+        }
+
+        it("it has an evaluable normal at t = 0.0") {
+            val normal = segment.normal(0.0)
+            normal.length.shouldBeNear(1.0, 10E-6)
+            println(normal)
         }
 
         it("can be split in half") {
@@ -71,6 +80,13 @@ object TestSegment : Spek({
             quadratic.position(0.5) `should be equal to` segment.position(0.5)
             quadratic.position(0.75) `should be equal to` segment.position(0.75)
             quadratic.position(1.0) `should be equal to` segment.position(1.0)
+
+            quadratic.normal(0.0) `should be near` segment.normal(0.0)
+            quadratic.normal(0.25) `should be near` segment.normal(0.25)
+            quadratic.normal(0.5) `should be near` segment.normal(0.5)
+            quadratic.normal(0.75) `should be near` segment.normal(0.75)
+            quadratic.normal(1.0) `should be near` segment.normal(1.0)
+
         }
 
         it("can be promoted to a cubic segment") {

--- a/openrndr-shape/src/test/kotlin/TestShape.kt
+++ b/openrndr-shape/src/test/kotlin/TestShape.kt
@@ -1,0 +1,52 @@
+import org.amshove.kluent.`should be equal to`
+import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
+import org.openrndr.shape.Winding
+import org.openrndr.shape.shape
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object TestShape : Spek({
+
+    describe("a shape") {
+        val width = 640
+        val height = 480
+
+        val s = shape {
+            contour {
+                moveTo(Vector2(width / 2.0 - 150.0, height / 2.0 - 150.00))
+                lineTo(cursor + Vector2(300.0, 0.0))
+                lineTo(cursor + Vector2(0.0, 300.0))
+                lineTo(anchor)
+                close()
+            }
+            contour {
+                moveTo(Vector2(width / 2.0 - 80.0, height / 2.0 - 100.0))
+                lineTo(cursor + Vector2(200.0, 0.0))
+                lineTo(cursor + Vector2(0.0, 200.00))
+                lineTo(anchor)
+                close()
+            }
+        }
+
+        it("should have 2 contours") {
+            s.contours.size `should be equal to` 2
+        }
+
+        it ("all contours should be closed") {
+            s.contours.all { it.closed } `should be equal to` true
+        }
+
+        it ("all contours have negative polarity") {
+            s.contours.all { it.polarity == YPolarity.CW_NEGATIVE_Y } `should be equal to` true
+        }
+
+        it ("first contour should have clockwise winding") {
+            s.contours.first().winding `should be equal to` Winding.CLOCKWISE
+        }
+
+        it("second contour should have counter-clockwise winding") {
+            s.contours[1].winding `should be equal to` Winding.COUNTER_CLOCKWISE
+        }
+    }
+})

--- a/openrndr-shape/src/test/kotlin/TestShapeContour.kt
+++ b/openrndr-shape/src/test/kotlin/TestShapeContour.kt
@@ -1,10 +1,7 @@
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should match all with`
 import org.openrndr.math.Vector2
-import org.openrndr.shape.Circle
-import org.openrndr.shape.Rectangle
-import org.openrndr.shape.SegmentJoin
-import org.openrndr.shape.contour
+import org.openrndr.shape.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -158,6 +155,10 @@ object TestShapeContour : Spek({
         val offset1 = offset0.offset(20.0, SegmentJoin.MITER)
         val positions1 = offset1.adaptivePositions()
         positions1.zipWithNext().`should match all with` { (it.second - it.first).squaredLength > 0.0 }
+
+        it("has CCW winding") {
+            curve.winding `should be equal to` Winding.COUNTER_CLOCKWISE
+        }
 
 
         it("can be sampled adaptively") {

--- a/openrndr-svg/build.gradle
+++ b/openrndr-svg/build.gradle
@@ -2,5 +2,6 @@ dependencies {
     implementation project(":openrndr-math")
     implementation project(":openrndr-color")
     implementation project(":openrndr-shape")
+    testImplementation project(":openrndr-core")
     implementation "org.jsoup:jsoup:$jsoupVersion"
 }

--- a/openrndr-svg/src/main/kotlin/org/openrndr/svg/SVGLoader.kt
+++ b/openrndr-svg/src/main/kotlin/org/openrndr/svg/SVGLoader.kt
@@ -6,8 +6,11 @@ import org.jsoup.parser.Parser
 import org.openrndr.color.ColorRGBa
 import org.openrndr.math.Matrix44
 import org.openrndr.math.Vector2
+import org.openrndr.math.YPolarity
 import org.openrndr.shape.*
 import java.io.File
+import java.net.MalformedURLException
+import java.net.URL
 import java.util.regex.Pattern
 
 /**
@@ -16,7 +19,16 @@ import java.util.regex.Pattern
  */
 fun loadSVG(fileOrUrlOrSvg: String): Composition {
     if (fileOrUrlOrSvg.endsWith(".svg")) {
-        return parseSVG(File(fileOrUrlOrSvg).readText())
+
+        try {
+            val url = URL(fileOrUrlOrSvg)
+            return parseSVG(url.readText())
+        } catch (e: MalformedURLException) {
+
+            return parseSVG(File(fileOrUrlOrSvg).readText())
+        }
+
+
     } else {
         return parseSVG(fileOrUrlOrSvg)
     }
@@ -342,7 +354,7 @@ internal class SVGPath : SVGElement() {
                     }
                 }
             }
-            ShapeContour(segments, closed)
+            ShapeContour(segments, closed, YPolarity.CW_NEGATIVE_Y)
         }
         return Shape(contours)
     }

--- a/openrndr-svg/src/test/kotlin/TestSVGLoader.kt
+++ b/openrndr-svg/src/test/kotlin/TestSVGLoader.kt
@@ -1,0 +1,24 @@
+package org.openrndr.math
+
+import org.amshove.kluent.`should be equal to`
+import org.openrndr.resourceUrl
+import org.openrndr.shape.Winding
+import org.openrndr.svg.loadSVG
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object TestSVGLoader : Spek({
+
+    describe("a simple SVG file") {
+        val composition = loadSVG(resourceUrl("/svg/closed-shapes.svg"))
+
+        it("has only closed shapes") {
+            composition.findShapes().all { it.shape.contours.all { it.closed } } `should be equal to` true
+        }
+
+        it("has only clockwise shapes") {
+            composition.findShapes().all { it.shape.contours.all { it.winding == Winding.CLOCKWISE } } `should be equal to` true
+        }
+    }
+
+})

--- a/openrndr-svg/src/test/resources/svg/closed-shapes.svg
+++ b/openrndr-svg/src/test/resources/svg/closed-shapes.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       transform="scale(1,-1)"
+       style="stroke-width:0.26458332"
+       y="-77.838989"
+       x="21.648832"
+       height="50.24667"
+       width="62.006531"
+       id="rect3986" />
+    <path
+       style="stroke-width:0.26458332"
+       d="M 103.70058,147.8636 76.811047,144.31094 58.640366,164.44784 53.709821,137.77655 28.943446,126.71785 52.785731,113.78674 55.64995,86.815187 75.315838,105.49461 101.8524,99.883982 90.1643,124.35961 Z"
+       id="path3990" />
+    <ellipse
+       style="stroke-width:0.26458332"
+       ry="28.33057"
+       rx="31.003265"
+       cy="39.084904"
+       cx="123.47852"
+       id="path3992" />
+    <ellipse
+       style="stroke-width:0.26458332"
+       ry="15.635267"
+       rx="9.3544331"
+       cy="106.83773"
+       cx="170.25069"
+       id="path3994" />
+    <circle
+       style="stroke-width:0.26458332"
+       r="37.952274"
+       cy="172.71967"
+       cx="145.39461"
+       id="path3996" />
+  </g>
+</svg>


### PR DESCRIPTION
Currently to get a gray scale color one needs to write `rgb(val, val, val)` instead of `rgb(val)`.
This PR tries to solve that.