### PR TITLE
Added standard blend mode for non-premultiplied alpha

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/DrawStyle.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/DrawStyle.kt
@@ -269,6 +269,7 @@ enum class DepthTestPass {
 
 enum class BlendMode {
     OVER,
+    BLEND,
     ADD,
     SUBTRACT,
     MULTIPLY,

--- a/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
+++ b/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
@@ -555,6 +555,11 @@ class DriverGL3(val version: DriverVersionGL) : Driver {
                 glBlendEquationi(0, GL_FUNC_ADD)
                 glBlendFunci(0, GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
             }
+            BlendMode.BLEND -> {
+                glEnable(GL_BLEND)
+                glBlendEquationi(0, GL_FUNC_ADD)
+                glBlendFunci(0, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+            }
             BlendMode.ADD -> {
                 glEnable(GL_BLEND)
                 glBlendEquationi(0, GL_FUNC_ADD)

--- a/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/RenderTargetGL3.kt
+++ b/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/RenderTargetGL3.kt
@@ -217,6 +217,11 @@ open class RenderTargetGL3(val framebuffer: Int,
                 glBlendEquationi(index, GL_FUNC_ADD)
                 glBlendFunci(index, GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
             }
+            BlendMode.BLEND -> {
+                glEnable(GL_BLEND)
+                glBlendEquationi(0, GL_FUNC_ADD)
+                glBlendFunci(0, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+            }
             BlendMode.REPLACE -> {
                 glEnable(GL_BLEND)
                 glBlendEquationi(index, GL_FUNC_ADD)


### PR DESCRIPTION
This is mainly a convenience for low-level drawing to allow the option of outputting colors directly without premultiplication.