### PR TITLE
Rename mouse.left to mouse.exited

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/Keys.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/Keys.kt
@@ -33,7 +33,7 @@ enum class MouseEventType {
     BUTTON_DOWN,
     SCROLLED,
     ENTERED,
-    LEFT
+    EXITED
 }
 
 /**

--- a/openrndr-core/src/main/kotlin/org/openrndr/Mouse.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/Mouse.kt
@@ -37,5 +37,5 @@ class Mouse(val application: Application) {
     val scrolled = Event<MouseEvent>("mouse-scrolled").postpone(true)
     val clicked = Event<MouseEvent>("mouse-clicked").postpone(true)
     val entered = Event<MouseEvent>("mouse-entered").postpone(true)
-    val left = Event<MouseEvent>("mouse-left").postpone(true)
+    val exited = Event<MouseEvent>("mouse-exited").postpone(true)
 }

--- a/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/ApplicationGLFWGL3.kt
+++ b/openrndr-gl3/src/main/kotlin/org/openrndr/internal/gl3/ApplicationGLFWGL3.kt
@@ -17,7 +17,6 @@ import org.openrndr.WindowMultisample.*
 import org.openrndr.animatable.Animatable
 import org.openrndr.animatable.Clock
 import org.openrndr.draw.Drawer
-import org.openrndr.exceptions.installUncaughtExceptionHandler
 import org.openrndr.internal.Driver
 import org.openrndr.math.Vector2
 import java.io.File
@@ -518,7 +517,7 @@ class ApplicationGLFWGL3(private val program: Program, private val configuration
             if (entered) {
                 program.mouse.entered.trigger(MouseEvent(program.mouse.position, Vector2.ZERO, Vector2.ZERO, MouseEventType.ENTERED, MouseButton.NONE, emptySet()))
             } else {
-                program.mouse.left.trigger(MouseEvent(program.mouse.position, Vector2.ZERO, Vector2.ZERO, MouseEventType.LEFT, MouseButton.NONE, emptySet()))
+                program.mouse.exited.trigger(MouseEvent(program.mouse.position, Vector2.ZERO, Vector2.ZERO, MouseEventType.EXITED, MouseButton.NONE, emptySet()))
             }
         }
 
@@ -695,7 +694,7 @@ class ApplicationGLFWGL3(private val program: Program, private val configuration
         program.mouse.buttonUp.deliver()
         program.mouse.dragged.deliver()
         program.mouse.entered.deliver()
-        program.mouse.left.deliver()
+        program.mouse.exited.deliver()
     }
 
     private fun drawFrame(): Throwable? {


### PR DESCRIPTION
The word `left` could be understood as left mouse button, when it refers to the mouse moving out of the window area.