### PR TITLE
Check for null in .parentFile()

### DIFF
--- a/openrndr-ffmpeg/src/main/kotlin/org/openrndr/ffmpeg/ScreenRecorder.kt
+++ b/openrndr-ffmpeg/src/main/kotlin/org/openrndr/ffmpeg/ScreenRecorder.kt
@@ -81,7 +81,7 @@ class ScreenRecorder : Extension {
         val filename = outputFile
                 ?: "video/$basename-${dt.year.z(4)}-${dt.month.value.z()}-${dt.dayOfMonth.z()}-${dt.hour.z()}.${dt.minute.z()}.${dt.second.z()}.${profile.fileExtension}"
 
-        File(filename).parentFile.let {
+        File(filename).parentFile?.let {
             if (!it.exists()) {
                 it.mkdirs()
             }


### PR DESCRIPTION
Was only working when specifying a relative or absolute existing path, not if setting just a file name"