### PR TITLE
Implement default font

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/draw/Drawer.kt
@@ -15,6 +15,7 @@ import org.openrndr.math.transforms.scale
 import org.openrndr.math.transforms.translate
 import org.openrndr.shape.*
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.URL
@@ -82,6 +83,15 @@ class Drawer(val driver: Driver) {
     private var qualityLineDrawer = QualityLineDrawer()
     private var qualityPolygonDrawer = QualityPolygonDrawer()
     internal val fontImageMapDrawer = FontImageMapDrawer()
+
+    private val defaultFontMap by lazy {
+        val defaultFontPath = "data/fonts/default.otf"
+        if (File(defaultFontPath).isFile) {
+            loadFont(defaultFontPath, 16.0)
+        } else {
+            null
+        }
+    }
 
     private val modelStack = Stack<Matrix44>()
     private val viewStack = Stack<Matrix44>()
@@ -428,8 +438,12 @@ class Drawer(val driver: Driver) {
         set(value) {
             drawStyle.fontMap = value
         }
-        get() = drawStyle.fontMap
-
+        get() {
+            if(drawStyle.fontMap == null) {
+                drawStyle.fontMap = defaultFontMap
+            }
+            return drawStyle.fontMap
+        }
 
     fun rectangle(rectangle: Rectangle) {
         rectangleDrawer.drawRectangle(context, drawStyle, rectangle.x, rectangle.y, rectangle.width, rectangle.height)

--- a/openrndr-core/src/main/kotlin/org/openrndr/text/Writer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/text/Writer.kt
@@ -86,10 +86,10 @@ class Writer(val drawerRef: Drawer?) {
 
     fun text(text: String, visible: Boolean = true) {
         // Triggers loading the default font (if needed) by accessing .fontMap
-        // otherwise makeRenderTokens() won't work
+        // otherwise makeRenderTokens() is not aware of the default font.
         drawerRef?.fontMap
-        val renderTokens = makeRenderTokens(text, false)
 
+        val renderTokens = makeRenderTokens(text, false)
 
         if (visible) {
             drawerRef?.let { d ->

--- a/openrndr-core/src/main/kotlin/org/openrndr/text/Writer.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/text/Writer.kt
@@ -85,6 +85,9 @@ class Writer(val drawerRef: Drawer?) {
                     (text.length - 1).coerceAtLeast(0) * style.tracking
 
     fun text(text: String, visible: Boolean = true) {
+        // Triggers loading the default font (if needed) by accessing .fontMap
+        // otherwise makeRenderTokens() won't work
+        drawerRef?.fontMap
         val renderTokens = makeRenderTokens(text, false)
 
 


### PR DESCRIPTION
For Drawer.text() and Writer.text()

Requires the presence of  `data/fonts/default.otf` (should be added to openrndr-template)

```
import org.openrndr.application
import org.openrndr.text.writer

fun main() = application {
    program {
        extend {
            drawer.translate(50.0, 50.0)
            writer {
                newLine()
                text("One line")
                newLine()
                text("Another line")
            }
            drawer.text("Hello", 250.0, 50.0)
        }
    }
}
```