### PR TITLE
Add captureEveryFrame and name properties

### DIFF
--- a/openrndr-extensions/src/main/kotlin/org/openrndr/extensions/Screenshots.kt
+++ b/openrndr-extensions/src/main/kotlin/org/openrndr/extensions/Screenshots.kt
@@ -96,6 +96,29 @@ open class Screenshots : Extension {
      */
     var folder: String? = "screenshots"
 
+    /**
+     * when true, capture every frame.
+     * when false, only capture on keypress.
+     */
+    var captureEveryFrame: Boolean = false
+        set(value) {
+            field = value
+            if (value) createScreenshot = AutoNamed
+        }
+
+    /**
+     * override automatic naming for screenshot
+     */
+    var name: String? = null
+        set(value) {
+            field = value
+            createScreenshot = if (value == null) {
+                None
+            } else {
+                Named(value)
+            }
+        }
+
     internal var createScreenshot: CreateScreenshot = None
 
     private var target: RenderTarget? = null
@@ -188,7 +211,9 @@ open class Screenshots : Extension {
 
             target?.destroy()
             resolved?.destroy()
-            this.createScreenshot = None
+            if (!this.captureEveryFrame) {
+                this.createScreenshot = None
+            }
 
             if (quitAfterScreenshot) {
                 program.application.exit()

--- a/openrndr-extensions/src/main/kotlin/org/openrndr/extensions/Screenshots.kt
+++ b/openrndr-extensions/src/main/kotlin/org/openrndr/extensions/Screenshots.kt
@@ -110,14 +110,6 @@ open class Screenshots : Extension {
      * override automatic naming for screenshot
      */
     var name: String? = null
-        set(value) {
-            field = value
-            createScreenshot = if (value == null) {
-                None
-            } else {
-                Named(value)
-            }
-        }
 
     internal var createScreenshot: CreateScreenshot = None
 
@@ -142,7 +134,7 @@ open class Screenshots : Extension {
      * Trigger screenshot creation
      */
     fun trigger() {
-        createScreenshot = AutoNamed
+        createScreenshot = if (name.isNullOrBlank()) AutoNamed else Named(name!!)
         programRef?.window?.requestDraw()
     }
 
@@ -164,7 +156,7 @@ open class Screenshots : Extension {
 
             filename = when (val cs = createScreenshot) {
                 None -> throw IllegalStateException("")
-                AutoNamed -> program.namedTimestamp("png", folder)
+                AutoNamed -> if (name.isNullOrBlank()) program.namedTimestamp("png", folder) else name
                 is Named -> cs.name
             }
 


### PR DESCRIPTION
Nothing really mind-blowing here, these are just some features I've been using locally that I thought others might enjoy.

`captureEveryFrame` does exactly what it sounds like, captures each frame without needing to trigger manually.

`name` offers the user a chance to customize the name beyond the AutoNamed function (e.g. if they want to add a small amount of metadata like a seed value).

I'm happy to contribute documentation for these properties too but I wasn't sure the best place to do it. Please let me know if that is desired.