### PR TITLE
Add centroid methods and make Shape properties fully computed instead of lazy

### DIFF
--- a/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
@@ -1005,6 +1005,15 @@ data class ShapeContour(val segments: List<Segment>, val closed: Boolean, val po
     val bounds get() = vector2Bounds(sampleLinear().segments.flatMap { listOf(it.start, it.end) })
 
     /**
+     * centroid of the shape contour if all segments were linear
+     */
+    val centroid: Vector2
+        get() {
+            val weightedAreas = triangulation.map { it.centroid.times(it.area) }
+            return Vector2(weightedAreas.sumByDouble { it.x } / weightedAreas.size, weightedAreas.sumByDouble { it.y } / weightedAreas.size)
+        }
+
+    /**
      * determine winding order of the contour
      */
     val winding: Winding

--- a/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
@@ -1009,8 +1009,14 @@ data class ShapeContour(val segments: List<Segment>, val closed: Boolean, val po
      */
     val centroid: Vector2
         get() {
-            val weightedAreas = triangulation.map { it.centroid.times(it.area) }
-            return Vector2(weightedAreas.sumByDouble { it.x } / weightedAreas.size, weightedAreas.sumByDouble { it.y } / weightedAreas.size)
+            val weightedCentroids = arrayListOf<Vector2>();
+            var totalWeight = 0.0;
+            for (t in triangulation) {
+                val a = t.area
+                weightedCentroids.add(t.centroid.times(a))
+                totalWeight += a
+            }
+            return Vector2(weightedCentroids.sumByDouble { it.x } / totalWeight, weightedCentroids.sumByDouble { it.y } / totalWeight)
         }
 
     /**

--- a/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/shape/Shape.kt
@@ -973,11 +973,12 @@ data class ShapeContour(val segments: List<Segment>, val closed: Boolean, val po
                 }
     }
 
-    val triangulation by lazy {
-        triangulate(Shape(listOf(this))).windowed(3, 3).map {
-            Triangle(it[0], it[1], it[2])
+    val triangulation: List<Triangle>
+        get() {
+            return triangulate(Shape(listOf(this))).windowed(3, 3).map {
+                Triangle(it[0], it[1], it[2])
+            }
         }
-    }
 
     init {
         segments.zipWithNext().forEach {
@@ -996,12 +997,12 @@ data class ShapeContour(val segments: List<Segment>, val closed: Boolean, val po
     /**
      * calculate approximate Euclidean length of the contour
      */
-    val length by lazy { segments.sumByDouble { it.length } }
+    val length get() = segments.sumByDouble { it.length }
 
     /**
      * calculate bounding box [Rectangle] of the contour
      */
-    val bounds by lazy { vector2Bounds(sampleLinear().segments.flatMap { listOf(it.start, it.end) }) }
+    val bounds get() = vector2Bounds(sampleLinear().segments.flatMap { listOf(it.start, it.end) })
 
     /**
      * determine winding order of the contour
@@ -1515,19 +1516,20 @@ class Shape(val contours: List<ShapeContour>) {
     /**
      * bounding box [Rectangle]
      */
-    val bounds by lazy {
-        if (empty) {
-            Rectangle(0.0, 0.0, 0.0, 0.0)
-        } else {
-            rectangleBounds(contours.mapNotNull {
-                if (it.empty) {
-                    null
-                } else {
-                    it.bounds
-                }
-            })
+    val bounds: Rectangle
+        get() {
+            return if (empty) {
+                Rectangle(0.0, 0.0, 0.0, 0.0)
+            } else {
+                rectangleBounds(contours.mapNotNull {
+                    if (it.empty) {
+                        null
+                    } else {
+                        it.bounds
+                    }
+                })
+            }
         }
-    }
 
     /**
      * indication of shape topology
@@ -1575,18 +1577,17 @@ class Shape(val contours: List<ShapeContour>) {
     /**
      * calculate triangulation for this shape
      */
-    val triangulation by lazy {
-        triangulate(this).windowed(3, 3).map {
-            Triangle(it[0], it[1], it[2])
+    val triangulation: List<Triangle>
+        get() {
+            return triangulate(this).windowed(3, 3).map {
+                Triangle(it[0], it[1], it[2])
+            }
         }
-    }
 
     /**
      * calculate (approximate) area for this shape (through triangulation)
      */
-    val area by lazy {
-        triangulation.sumByDouble { it.area }
-    }
+    val area get() = triangulation.sumByDouble { it.area }
 
     /**
      * generate random points that lie inside the shape

--- a/openrndr-core/src/main/kotlin/org/openrndr/shape/Triangle.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/shape/Triangle.kt
@@ -47,11 +47,12 @@ data class Triangle(val x1: Vector2, val x2: Vector2, val x3: Vector2) {
         return x1 * b.x + x2 * b.y + x3 * b.z
     }
 
-    val area by lazy {
-        val u = x2 - x1
-        val v = x3 - x1
-        abs(u cross v) / 2.0
-    }
+    val area: Double
+        get() {
+            val u = x2 - x1
+            val v = x3 - x1
+            return abs(u cross v) / 2.0
+        }
 
     operator fun times(scale: Double): Triangle {
         return Triangle(x1 * scale, x2 * scale, x3 * scale)

--- a/openrndr-core/src/main/kotlin/org/openrndr/shape/Triangle.kt
+++ b/openrndr-core/src/main/kotlin/org/openrndr/shape/Triangle.kt
@@ -54,6 +54,8 @@ data class Triangle(val x1: Vector2, val x2: Vector2, val x3: Vector2) {
             return abs(u cross v) / 2.0
         }
 
+    val centroid get() = x1.plus(x2).plus(x3).div(3.0);
+
     operator fun times(scale: Double): Triangle {
         return Triangle(x1 * scale, x2 * scale, x3 * scale)
     }


### PR DESCRIPTION
Removing lazy may be controversial -- I don't know how much impact this will have for the typical OPENRNDR user.  Here is why I am proposing this:

My current project involves computing 4 million polygons of 50 segments each.  This barely fits in to a 32GB heap with enough room for GC to function efficiently.  Retaining the results of triangulate etc on-heap is enough to make it not fit.

Open to better solutions, but switching to fully computed properties was simple enough for me to hack out!