### PR TITLE
Fix artifex intersections edge case

### DIFF
--- a/openrndr-adopted-artifex/src/main/java/io/lacuna/artifex/utils/Scalars.java
+++ b/openrndr-adopted-artifex/src/main/java/io/lacuna/artifex/utils/Scalars.java
@@ -59,7 +59,11 @@ public class Scalars {
   }
 
   public static double normalizationFactor(double a, double b, double c) {
-    double exponent = getExponent(max(max(a, b), c));
+    double maxValue = max(a, b, c);
+    if(maxValue == 0.0) {
+      maxValue = min(a, b, c);
+    }
+    double exponent = getExponent(maxValue);
     return (exponent < -8 || exponent > 8) ? Math.pow(2, -exponent) : 1;
   }
 
@@ -74,5 +78,13 @@ public class Scalars {
 
   public static double max(double a, double b, double c) {
     return max(a, max(b, c));
+  }
+
+  public static double min(double a, double b) {
+    return a > b ? b : a;
+  }
+
+  public static double min(double a, double b, double c) {
+    return min(a, min(b, c));
   }
 }


### PR DESCRIPTION
Reasoning behind this PR at https://github.com/lacuna/artifex/issues/3

Maybe there's a way to avoid calling both max and min in the worst case?

I can't say if assigning `min(a, b, c)` is the right approach when maxValue is 0.0 since I don't know the purpose of the normalizationFactor, but I have tested it on a number of programs and they all worked correctly. Also cases where intersections were previously not detected now give the expected result.