### PR TITLE
Make chaikinSmooth work well when startp=endp

### DIFF
--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
@@ -10,7 +10,7 @@ package org.openrndr.math
  * @param closed when the polyline is supposed to be a closed shape
  * @param bias a value above 0.0 and below 0.5 controlling
  * where new vertices are located. Lower values produce vertices near
- * existing vertices. Values near 0.5 produce biases new vertices towards
+ * existing vertices. Values near 0.5 biases new vertices towards
  * the mid point between existing vertices.
  */
 tailrec fun chaikinSmooth(

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
@@ -8,39 +8,39 @@ package org.openrndr.math
  * @param polyline a list of vectors describing the polyline
  * @param iterations the number of times to approximate
  * @param closed when the polyline is supposed to be a closed shape
+ * @param bias a value above 0.0 and below 0.5 controlling
+ * where new vertices are located. Lower values produce vertices near
+ * existing vertices. Values near 0.5 produce biases new vertices towards
+ * the mid point between existing vertices.
  */
-fun chaikinSmooth(polyline: List<Vector2>, iterations: Int = 1, closed: Boolean = false): List<Vector2> {
-    if (iterations <= 0) {
+tailrec fun chaikinSmooth(
+    polyline: List<Vector2>,
+    iterations: Int = 1,
+    closed: Boolean = false,
+    bias: Double = 0.25
+): List<Vector2> {
+    if (iterations <= 0 || polyline.size < 2) {
         return polyline
     }
 
-    val output = mutableListOf<Vector2>()
-
-    if (!closed && polyline.isNotEmpty()) {
-        output.add(polyline.first().copy())
+    val result = if (closed) {
+        (if (polyline.first() == polyline.last()) polyline else
+            (polyline + polyline.first())).zipWithNext { p0, p1 ->
+            listOf(
+                p0.mix(p1, bias),
+                p0.mix(p1, 1 - bias)
+            )
+        }.flatten()
+    } else {
+        listOf(polyline.first().copy()) +
+                polyline.zipWithNext { p0, p1 ->
+                    listOf(
+                        p0.mix(p1, bias),
+                        p0.mix(p1, 1 - bias)
+                    )
+                }.flatten() +
+                polyline.last().copy()
     }
 
-    val count = if (closed) polyline.size else polyline.size - 1
-
-    for (i in 0 until count) {
-        val p0 = polyline[i]
-        val p1 = polyline[(i + 1) % polyline.size]
-
-        val p0x = p0.x
-        val p0y = p0.y
-        val p1x = p1.x
-        val p1y = p1.y
-
-        val Q = Vector2(0.75 * p0x + 0.25 * p1x, 0.75 * p0y + 0.25 * p1y)
-        val R = Vector2(0.25 * p0x + 0.75 * p1x, 0.25 * p0y + 0.75 * p1y)
-
-        output.add(Q)
-        output.add(R)
-    }
-
-    if (!closed && polyline.isNotEmpty()) {
-        output.add(polyline.last().copy())
-    }
-
-    return chaikinSmooth(output, iterations - 1, closed)
+    return chaikinSmooth(result, iterations - 1, closed)
 }

--- a/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
+++ b/openrndr-math/src/main/kotlin/org/openrndr/math/Chaikin.kt
@@ -42,5 +42,5 @@ tailrec fun chaikinSmooth(
                 polyline.last().copy()
     }
 
-    return chaikinSmooth(result, iterations - 1, closed)
+    return chaikinSmooth(result, iterations - 1, closed, bias)
 }


### PR DESCRIPTION
Add bias argument for more control over the resulting shape

Require 2 points, not just not-empty.

More idiomatic Kotlin.