### PR TITLE
Revert "Upgrade to kotlin-logging 2.0.8"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ allprojects {
     }
 
     dependencies {
-        implementation 'io.github.microutils:kotlin-logging-jvm:2.0.8'
+        implementation 'io.github.microutils:kotlin-logging-jvm:2.0.6'
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0-RC'
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 


### PR DESCRIPTION
I am not seeing a kotlin logging 2.0.8 on maven, currently master is broken due to it.