### PR TITLE
Primitive shapes inherit from common interfaces

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Circle.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Circle.kt
@@ -12,7 +12,7 @@ import kotlin.math.abs
  *
  * Alternatively, see [Ellipse].
  */
-data class Circle(val center: Vector2, val radius: Double) {
+data class Circle(val center: Vector2, val radius: Double): Movable, Scalable1D {
     constructor(x: Double, y: Double, radius: Double) : this(Vector2(x, y), radius)
 
     companion object {
@@ -57,17 +57,40 @@ data class Circle(val center: Vector2, val radius: Double) {
         }
     }
 
+    /** The top-left corner of the [Circle]. */
+    val corner: Vector2
+        get() = center - scale
+
+    override val scale: Vector2
+        get() = Vector2(radius)
+
     /** Creates a new [Circle] with the current [center] offset by [offset]. */
+    @Deprecated("Vague naming", ReplaceWith("movedBy(offset)"))
     fun moved(offset: Vector2): Circle = Circle(center + offset, radius)
 
-    /** Creates a new [Circle] with center at [position]. */
-    fun movedTo(position: Vector2): Circle = Circle(position, radius)
+    override fun movedBy(offset: Vector2): Circle = Circle(center + offset, radius)
 
-    /** Creates a new [Circle] with scale specified by a multiplier for the current radius. */
+    /** Creates a new [Circle] with center at [center]. */
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun movedTo(center: Vector2) = Circle(center, radius)
+
+    /** Creates a new [Circle] with the [scale] specified as a multiplier for the current radius. */
+    @Deprecated("Vague naming", ReplaceWith("scaledBy(scale)"))
     fun scaled(scale: Double): Circle = Circle(center, radius * scale)
 
-    /** Creates a new [Circle] at the same position with given radius. */
-    fun scaledTo(fitRadius: Double) = Circle(center, fitRadius)
+    override fun scaledBy(scale: Double, uAnchor: Double, vAnchor: Double): Circle {
+        val d = corner - position(uAnchor, vAnchor)
+        val nd = position(uAnchor, vAnchor) + d * Vector2(scale)
+        return Circle(nd, radius * scale)
+    }
+
+    /** Creates a new [Circle] at the same position with the given [radius]. */
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun scaledTo(radius: Double) = Circle(center, radius)
+
+    override fun position(u: Double, v: Double): Vector2 {
+        return corner + Vector2(u * radius, v * radius)
+    }
 
     /** Returns true if given [point] lies inside the [Shape]. */
     fun contains(point: Vector2): Boolean = point.minus(center).squaredLength < radius * radius

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Ellipse.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Ellipse.kt
@@ -5,7 +5,7 @@ import org.openrndr.math.Vector2
 /**
  * Creates a new [Ellipse].
  *
- * Also see [OrientedEllipse] and [Circle].
+ * Also see [Circle].
  *
  * @param xRadius Horizontal radius.
  * @param yRadius Vertical radius.

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/IntRectangle.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/IntRectangle.kt
@@ -7,7 +7,7 @@ import org.openrndr.math.IntVector2
  *
  * Uses [IntVector2]s which require whole numbers (integers) for position and dimensions.
  *
- * Also see [Rectangle] and [OrientedRectangle].
+ * Also see [Rectangle].
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 data class IntRectangle(val corner: IntVector2, val width: Int, val height: Int) {

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/MovableScalable.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/MovableScalable.kt
@@ -1,0 +1,57 @@
+package org.openrndr.shape
+
+import org.openrndr.math.*
+
+sealed interface Movable {
+    /** Creates a new shape with the same size but the current position [offset] by the given amount. */
+    fun movedBy(offset: Vector2): Movable
+
+    /** Creates a new shape with the same size but the current position is set to [position]. */
+    fun movedTo(position: Vector2): Movable
+}
+
+sealed interface Scalable1D {
+    /** Current scale of this shape. Generally equivalent to its dimensions. */
+    val scale: Vector2
+
+    /**
+     * Returns a position in the bounding box for parameterized
+     * values [u] and [v] between `0.0` and `1.0` where
+     * (`0.5`, `0.5`) is the center of the bounding box.
+     */
+    fun position(u: Double, v: Double): Vector2
+
+    /**
+     * Returns a position in the bounding box for a parameterized
+     * [uv] value between (`0.0`, `0.0`) and (`1.0`, `1.0`) where
+     * (`0.5`, `0.5`) is the center of the bounding box.
+     */
+    fun position(uv: Vector2) = position(uv.x, uv.y)
+
+    /**
+     * Creates a new shape with dimensions scaled by [scale].
+     *
+     * @param scale the scale factor
+     * @param uAnchor x coordinate of the scaling anchor in u parameter space, default is 0.5 (center)
+     * @param vAnchor y coordinate of the scaling anchor in v parameter space, default is 0.5 (center)
+     */
+    fun scaledBy(scale: Double, uAnchor: Double = 0.5, vAnchor: Double = 0.5): Scalable1D
+
+    /** Creates a new shape at the same position with the given dimension, scaled uniformly. */
+    fun scaledTo(size: Double): Scalable1D
+}
+
+sealed interface Scalable2D : Scalable1D {
+    /**
+     * Creates a new shape with dimensions scaled by [xScale] and [yScale].
+     *
+     * @param xScale the x scale factor
+     * @param yScale the y scale factor
+     * @param uAnchor x coordinate of the scaling anchor in u parameter space, default is 0.5 (center)
+     * @param vAnchor y coordinate of the scaling anchor in v parameter space, default is 0.5 (center)
+     */
+    fun scaledBy(xScale: Double, yScale: Double, uAnchor: Double = 0.5, vAnchor: Double = 0.5): Scalable2D
+
+    /** Creates a new shape at the same position with the given dimensions. */
+    fun scaledTo(width: Double, height: Double): Scalable2D
+}

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Rectangle.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Rectangle.kt
@@ -12,7 +12,7 @@ import kotlin.math.min
 /**
  * Creates a new [Rectangle].
  *
- * Also see [OrientedRectangle] and [IntRectangle].
+ * Also see [IntRectangle].
  */
 data class Rectangle(val corner: Vector2, val width: Double, val height: Double = width) {
 

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Rectangle.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Rectangle.kt
@@ -14,7 +14,7 @@ import kotlin.math.min
  *
  * Also see [IntRectangle].
  */
-data class Rectangle(val corner: Vector2, val width: Double, val height: Double = width) {
+data class Rectangle(val corner: Vector2, val width: Double, val height: Double = width) : Movable, Scalable2D {
 
     constructor(x: Double, y: Double, width: Double, height: Double = width) :
             this(Vector2(x, y), width, height)
@@ -31,20 +31,11 @@ data class Rectangle(val corner: Vector2, val width: Double, val height: Double 
     val dimensions: Vector2
         get() = Vector2(width, height)
 
-    /**
-     * Returns a position for parameterized values [u] and [v] between `0.0` and `1.0`
-     * where (`0.5`, `0.5`) is the center of the rectangle.
-     */
-    fun position(u: Double, v: Double): Vector2 {
-        return corner + Vector2(u * width, v * height)
-    }
+    override val scale: Vector2
+        get() = dimensions
 
-    /**
-     * Returns a position for a parameterized [uv] value between (`0.0`, `0.0`)
-     * and (`1.0`, `1.0`) where (`0.5`, `0.5`) is the center of the rectangle.
-     */
-    fun position(uv: Vector2): Vector2 {
-        return corner + uv * dimensions
+    override fun position(u: Double, v: Double): Vector2 {
+        return corner + Vector2(u * width, v * height)
     }
 
     /** The [x]-coordinate of the top-left corner. */
@@ -89,13 +80,12 @@ data class Rectangle(val corner: Vector2, val width: Double, val height: Double 
      * @param anchorU x coordinate of the scaling anchor in u parameter space, default is 0.5 (center)
      * @param anchorV y coordinate of the scaling anchor in v parameter space, default is 0.5 (center)
      */
+    @Deprecated("Vague naming", ReplaceWith("scaledBy(scale, scaleY)"))
     fun scale(scale: Double, scaleY: Double = scale, anchorU: Double = 0.5, anchorV: Double = 0.5): Rectangle {
-        val d = corner - position(anchorU, anchorV)
-        val nd = position(anchorU, anchorV) + d * Vector2(scale, scaleY)
-        return Rectangle(nd, width * scale, height * scaleY)
+        return scaledBy(scale, scaleY, anchorU, anchorV) as Rectangle
     }
 
-    @Deprecated("use scale instead", ReplaceWith("scale(scale, scaleY)"))
+    @Deprecated("Doesn't account for anchor placement", ReplaceWith("scaledBy(scale, scaleY)"))
     fun scaled(scale: Double, scaleY: Double = scale): Rectangle {
         return Rectangle(corner, width * scale, height * scaleY)
     }
@@ -113,9 +103,27 @@ data class Rectangle(val corner: Vector2, val width: Double, val height: Double 
     }
 
     /** Creates a new [Rectangle] with the same size but the current position offset by [offset] amount. */
+    @Deprecated("Vague naming", ReplaceWith("movedBy(offset)"))
     fun moved(offset: Vector2): Rectangle {
         return Rectangle(corner + offset, width, height)
     }
+
+    override fun movedBy(offset: Vector2): Movable = Rectangle(corner + offset, width, height)
+
+    override fun movedTo(position: Vector2): Movable = Rectangle(position, width, height)
+
+    override fun scaledBy(xScale: Double, yScale: Double, uAnchor: Double, vAnchor: Double): Scalable2D {
+        val d = corner - position(uAnchor, vAnchor)
+        val nd = position(uAnchor, vAnchor) + d * Vector2(xScale, yScale)
+        return Rectangle(nd, width * xScale, height * yScale)
+    }
+
+    override fun scaledBy(scale: Double, uAnchor: Double, vAnchor: Double): Scalable1D =
+        scaledBy(scale, scale, uAnchor, vAnchor)
+
+    override fun scaledTo(width: Double, height: Double): Scalable2D = Rectangle(corner, width, height)
+
+    override fun scaledTo(size: Double): Scalable1D = scaledTo(size, size)
 
     /**
      * Returns true if given [point] is inside the [Rectangle].


### PR DESCRIPTION
(Potentially) breaking changes:
1. `Circle.scaledTo(fitRadius)` is now `Circle.scaledTo(radius)`
2. `Ellipse.scaledTo(xFitRadius, yFitRadius = xFitRadius)` has been replaced by 
    `Ellipse.scaledTo(xRadius, yRadius)` and 
    `Ellipse.scaledTo(radius)`

Closes #239 