### PR TITLE
Document Color classes

### DIFF
--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorATV.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorATV.kt
@@ -2,6 +2,7 @@ package org.openrndr.color
 
 import kotlin.math.pow
 
+@Deprecated("Used solely by the also-deprecated ColorATVa.")
 data class Hue(
     val name: Int,
     val lambda: Double,
@@ -67,6 +68,11 @@ val hues = listOf(
 
 fun findHue(id: Int): Hue? = hues.find { it.name == id }
 
+/**
+ * The little-known [Coloroid color space](https://en.wikipedia.org/wiki/Coloroid).
+ * There is a color atlas of [hues], but their source has not been digitized.
+ */
+@Deprecated("Largely unknown format with a practically unverifiable list of colors.")
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 data class ColorATVa(val id: Int, val t: Double, val v: Double, val alpha: Double = 1.0) {
 

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSLa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSLa.kt
@@ -3,11 +3,14 @@ package org.openrndr.color
 import org.openrndr.math.mixAngle
 
 /**
- * color in HSL space
- * @param h hue in degrees (0 .. 360)
- * @param s saturation (0.0 .. 1.0)
- * @param l lightness (0.0 .. 1.0)
- * @param a alpha (0.0. .. 1.0)
+ * The [HSL color space](https://en.wikipedia.org/wiki/HSL_and_HSV).
+ *
+ * @see ColorHSVa
+ *
+ * @param h hue in degrees, where a full rotation is 360.0 degrees
+ * @param s saturation as a percentage between 0.0 and 1.0
+ * @param l lightness/luminance as a percentage between 0.0 and 1.0
+ * @param a alpha as a percentage between 0.0 and 1.0
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 data class ColorHSLa(val h: Double, val s: Double, val l: Double, val a: Double = 1.0) :
@@ -126,11 +129,12 @@ fun hsl(h: Double, s: Double, l: Double) = ColorHSLa(h, s, l)
 fun hsla(h: Double, s: Double, l: Double, a: Double) = ColorHSLa(h, s, l, a)
 
 /**
- * Mixes two colors in HSLa space
- * @param left the left hand ColorHSLa color
- * @param right the right hand ColorHSLa
- * @param x the mix amount
- * @return a mix of [left] and [right], x == 0.0 corresponds with left, x == 1.0 corresponds with right
+ * Weighted mix between two colors in the HSL color space.
+ * @param left the left-hand ColorHSLa to mix
+ * @param right the right-hand ColorHSLa to mix
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
  */
 fun mix(left: ColorHSLa, right: ColorHSLa, x: Double): ColorHSLa {
     val sx = x.coerceIn(0.0, 1.0)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSVa.kt
@@ -8,12 +8,14 @@ import kotlin.math.floor
 
 
 /**
- * A color respresentation in HSVa space
+ * The [HSV color space](https://en.wikipedia.org/wiki/HSL_and_HSV).
  *
- * @param h hue in n * [0, 360)
- * @param s value in [0, 1]
- * @param v value in [0, 1]
- * @param a alpha in [0, 1]
+ * @see ColorHSLa
+ *
+ * @param h hue in degrees, where a full rotation is 360.0 degrees
+ * @param s saturation as a percentage between 0.0 and 1.0
+ * @param v value/brightness as a percentage between 0.0 and 1.0
+ * @param a alpha as a percentage between 0.0 and 1.0
  */
 @Suppress("unused")
 data class ColorHSVa(val h: Double, val s: Double, val v: Double, val a: Double = 1.0) :
@@ -168,11 +170,12 @@ fun hsv(h: Double, s: Double, v: Double) = ColorHSVa(h, s, v)
 fun hsva(h: Double, s: Double, v: Double, a: Double) = ColorHSVa(h, s, v, a)
 
 /**
- * Mixes two colors in HSVa space
- * @param left the left hand ColorHSVa color
- * @param right the right hand ColorHSVa
- * @param x the mix amount
- * @return a mix of [left] and [right], x == 0.0 corresponds with left, x == 1.0 corresponds with right
+ * Weighted mix between two colors in the HSVa color space.
+ * @param left the left-hand ColorHSVa to mix
+ * @param right the right-hand ColorHSVa to mix
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
  */
 fun mix(left: ColorHSVa, right: ColorHSVa, x: Double): ColorHSVa {
     val sx = x.coerceIn(0.0, 1.0)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorInterfaces.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorInterfaces.kt
@@ -2,60 +2,36 @@ package org.openrndr.color
 
 import org.openrndr.math.LinearType
 
-/**
- * interface for colors that can be converted to [ColorRGBa]
- */
 interface ConvertibleToColorRGBa {
-    /**
-     * convert to [ColorRGBa]
-     */
+    /** Convert into [ColorRGBa]. */
     fun toRGBa(): ColorRGBa
 }
-/**
- * interface for shadable colors
- */
+
 interface ShadableColor<T> {
-    /**
-     * shades the color by multiplication
-     * @param factor the shade factor
-     */
+    /** Multiply the shade by a factor. */
     fun shade(factor: Double): T
 }
 
-/**
- * interface for hue-shiftable colors
- */
 interface HueShiftableColor<T> {
     /**
-     * shift the hue by a given amount of degrees
+     * Shift the hue of a color by the given amount of degrees.
      * @param shiftInDegrees the hue shift in degrees
      */
     fun shiftHue(shiftInDegrees: Double): T
 }
 
-/**
- * interface for saturatable color
- */
 interface SaturatableColor<T> {
-    /**
-     * adjust saturation by multiplication
-     */
+    /** Multiply the saturation by a factor. */
     fun saturate(factor: Double): T
 }
 
-/**
- * interface for opacifable color
- */
 interface OpacifiableColor<T> {
-    /**
-     * adjust opacity by multiplication
-     */
+    /** Multiply the opacity by a factor */
     fun opacify(factor: Double): T
 }
 
-
 /**
- * interface for algebraic color
+ * Allows performing select algebraic operations on colors of this kind.
  */
 interface AlgebraicColor<T : AlgebraicColor<T>> : LinearType<T> {
     override operator fun div(scale: Double): T = times(1.0 / scale)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLABa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLABa.kt
@@ -4,6 +4,18 @@ import org.openrndr.math.CastableToVector4
 import org.openrndr.math.Vector4
 import kotlin.math.pow
 
+/**
+ * The [CIELAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space),
+ * more commonly known as Lab.
+ *
+ * @param l lightness, between 0.0 (black) and 100.0 (white)
+ * @param a unbounded a* axis, relative to the green–red opponent colors,
+ *          with negative values toward green and positive values toward red
+ * @param b unbounded b* axis, relative to the blue–yellow opponent colors,
+ *          with negative values toward blue and positive values toward yellow
+ * @param alpha alpha as a percentage between 0.0 and 1.0
+ * @param ref reference white against which the color values are calculated
+ */
 data class ColorLABa(
     val l: Double,
     val a: Double,
@@ -18,6 +30,7 @@ data class ColorLABa(
     AlgebraicColor<ColorLABa> {
 
     companion object {
+        // https://web.archive.org/web/20191228145700/http://eilv.cie.co.at/term/157
         fun fromXYZa(xyz: ColorXYZa, ref: ColorXYZa): ColorLABa {
             val x = xyz.x / ref.x
             val y = xyz.y / ref.y

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLCHABa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLCHABa.kt
@@ -5,6 +5,18 @@ import org.openrndr.math.asRadians
 import org.openrndr.math.mixAngle
 import kotlin.math.*
 
+/**
+ * The [CIELChAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space#Cylindrical_model)
+ * is the cylindrical representation of the CIELAB color space.
+ *
+ * @param l luminance, in a range of 0.0 (darkest) to 100.0 (brightest)
+ * @param c chroma
+ * @param h hue in degrees, where a full rotation is 360.0 degrees
+ * @param alpha alpha as a percentage between 0.0 and 1.0
+ * @param ref reference white against which the color values are calculated
+ *
+ * @see ColorLABa
+ */
 data class ColorLCHABa(
     val l: Double,
     val c: Double,
@@ -101,6 +113,14 @@ data class ColorLCHABa(
     override fun mix(other: ColorLCHABa, factor: Double) = mix(this, other, factor)
 }
 
+/**
+ * Weighted mix between two colors in the LChAB color space.
+ * @param left the left-hand ColorLCHABa to mix
+ * @param right the right-hand ColorLCHABa to mix
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
+ */
 fun mix(left: ColorLCHABa, right: ColorLCHABa, x: Double): ColorLCHABa {
     val sx = x.coerceIn(0.0, 1.0)
     return ColorLCHABa(

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLCHUVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLCHUVa.kt
@@ -5,6 +5,18 @@ import org.openrndr.math.asRadians
 import org.openrndr.math.mixAngle
 import kotlin.math.*
 
+/**
+ * The [CIELChUV color space](https://en.wikipedia.org/wiki/CIELUV#Cylindrical_representation_(CIELCh))
+ * is the cylindrical representation of the CIELUV color space.
+ *
+ * @param l luminance, in a range of 0.0 (darkest) to 100.0 (brightest)
+ * @param c chroma
+ * @param h hue in degrees, where a full rotation is 360.0 degrees
+ * @param alpha alpha as a percentage between 0.0 and 1.0
+ * @param ref reference white against which the color values are calculated
+ *
+ * @see ColorLUVa
+ */
 data class ColorLCHUVa(
     val l: Double,
     val c: Double,
@@ -96,7 +108,13 @@ data class ColorLCHUVa(
     override fun mix(other: ColorLCHUVa, factor: Double) = mix(this, other, factor)
 }
 
-
+/**
+ * Weighted mix between two colors in the LChUV color space.
+ *
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
+ */
 fun mix(left: ColorLCHUVa, right: ColorLCHUVa, x: Double): ColorLCHUVa {
     val sx = x.coerceIn(0.0, 1.0)
     return ColorLCHUVa(

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLSHABa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLSHABa.kt
@@ -1,5 +1,11 @@
 package org.openrndr.color
 
+/**
+ * Based on [ColorLCHABa], but
+ * instead tries to use a normalized chroma.
+ *
+ * @see ColorLCHABa
+ */
 data class ColorLSHABa(
     val l: Double,
     val s: Double,

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLSHUVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLSHUVa.kt
@@ -1,6 +1,11 @@
 package org.openrndr.color
 
-
+/**
+ * Based on [ColorLCHUVa], but
+ * instead tries to use a normalized chroma.
+ *
+ * @see ColorLCHUVa
+ */
 data class ColorLSHUVa(
     val l: Double,
     val s: Double,

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLUVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorLUVa.kt
@@ -4,6 +4,14 @@ import org.openrndr.math.CastableToVector4
 import org.openrndr.math.Vector4
 import kotlin.math.pow
 
+/**
+ * The [CIELUV color space](https://en.wikipedia.org/wiki/CIELUV)
+ * @param l luminance, in a range of 0.0 (darkest) to 100.0 (brightest)
+ * @param u unbounded chromaticity coordinate U
+ * @param v unbounded chromaticity coordinate V
+ * @param alpha alpha as a percentage between 0.0 and 1.0
+ * @param ref reference white against which the color values are calculated
+ */
 @Suppress("unused", "UNUSED_PARAMETER")
 data class ColorLUVa(val l: Double, val u: Double, val v: Double, val alpha: Double = 1.0, val ref: ColorXYZa) :
     ConvertibleToColorRGBa,

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorRGBa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorRGBa.kt
@@ -16,12 +16,13 @@ enum class Linearity {
 }
 
 /**
- * color in RGBa space
+ * A generic RGB color space capable of representing
+ * both the linear and the sRGB color spaces.
  *
- * @param r red between 0 and 1
- * @param g green between 0 and 1
- * @param b blue between 0 and 1
- * @param a alpha between 0 and 1
+ * @param r red as a percentage between 0.0 and 1.0
+ * @param g green as a percentage between 0.0 and 1.0
+ * @param b blue as a percentage between 0.0 and 1.0
+ * @param a alpha as a percentage between 0.0 and 1.0
  */
 @Suppress("EqualsOrHashCode") // generated equals() is ok, only hashCode() needs to be overridden
 data class ColorRGBa(
@@ -257,7 +258,10 @@ data class ColorRGBa(
 }
 
 /**
- * Mixes two colors in RGBa space
+ * Weighted mix between two colors in the generic RGB color space.
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
  */
 fun mix(left: ColorRGBa, right: ColorRGBa, x: Double): ColorRGBa {
     val sx = x.coerceIn(0.0, 1.0)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXSLa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXSLa.kt
@@ -2,6 +2,14 @@ package org.openrndr.color
 
 import org.openrndr.math.mixAngle
 
+/**
+ * Practically identical to [ColorHSLa], but
+ * for mapping colors to classical painter's scheme
+ * of complementary colors.
+ *
+ * @see ColorHSLa
+ * @see ColorXSVa
+ */
 data class ColorXSLa(val x: Double, val s: Double, val l: Double, val a: Double) :
     ConvertibleToColorRGBa,
     ShadableColor<ColorXSLa>,
@@ -67,11 +75,11 @@ private fun map(x: Double, a: Double, b: Double, c: Double, d: Double): Double {
 }
 
 /**
- * Mixes two colors in XSLa space
- * @param left the left hand ColorXSLa color
- * @param right the right hand ColorXSLa
- * @param x the mix amount
- * @return a mix of [left] and [right], x == 0.0 corresponds with left, x == 1.0 corresponds with right
+ * Weighted mix between two colors in the XSL color space.
+ *
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
  */
 fun mix(left: ColorXSLa, right: ColorXSLa, x: Double): ColorXSLa {
     val sx = x.coerceIn(0.0, 1.0)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXSVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXSVa.kt
@@ -2,6 +2,14 @@ package org.openrndr.color
 
 import org.openrndr.math.mixAngle
 
+/**
+ * Practically identical to [ColorHSVa], but
+ * for mapping colors to classical painter's scheme
+ * of complementary colors.
+ *
+ * @see ColorHSVa
+ * @see ColorXSLa
+ */
 data class ColorXSVa(val x: Double, val s: Double, val v: Double, val a: Double = 1.0) :
     ConvertibleToColorRGBa,
     ShadableColor<ColorXSVa>,
@@ -67,11 +75,11 @@ private fun map(x: Double, a: Double, b: Double, c: Double, d: Double): Double {
 }
 
 /**
- * Mixes two colors in XSVa space
- * @param left the left hand ColorXSVa color
- * @param right the right hand ColorXSVa
- * @param x the mix amount
- * @return a mix of [left] and [right], x == 0.0 corresponds with left, x == 1.0 corresponds with right
+ * Weighted mix between two colors in the XSV color space.
+ *
+ * @param x the weighting of colors, a value 0.0 is equivalent to [left],
+ * 1.0 is equivalent to [right] and at 0.5 both colors contribute to the result equally
+ * @return a mix of [left] and [right] weighted by [x]
  */
 fun mix(left: ColorXSVa, right: ColorXSVa, x: Double): ColorXSVa {
     val sx = x.coerceIn(0.0, 1.0)

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXYZ.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorXYZ.kt
@@ -4,6 +4,14 @@ import org.openrndr.math.CastableToVector4
 import org.openrndr.math.Vector4
 import kotlin.math.min
 
+/**
+ * The [CIE XYZ color space](https://en.wikipedia.org/wiki/CIE_1931_color_space#Definition_of_the_CIE_XYZ_color_space).
+ *
+ * @param x first chromaticity coordinate, mix of the three CIE RGB curves chosen to be nonnegative
+ * @param y luminance of the color, in a range of 0.0 (darkest) to 100.0 (brightest)
+ * @param z second chromaticity coordinate, quasi-equal to blue
+ * @param a alpha as a percentage between 0.0 and 1.0
+ */
 data class ColorXYZa(val x: Double, val y: Double, val z: Double, val a: Double = 1.0) :
     ConvertibleToColorRGBa,
     CastableToVector4,
@@ -12,24 +20,28 @@ data class ColorXYZa(val x: Double, val y: Double, val z: Double, val a: Double 
 
     @Suppress("unused")
     companion object {
+        // White points of standard illuminants as per the CIE 1931 2° Standard Observer
+        // Also see: https://en.wikipedia.org/wiki/CIE_1931_color_space#CIE_standard_observer,
+        // https://en.wikipedia.org/wiki/Standard_illuminant#White_points_of_standard_illuminants
         val SO2_A = ColorXYZa(109.83, 100.0, 35.55)
         val SO2_C = ColorXYZa(98.04, 100.0, 118.11)
-        val SO2_D65 = ColorXYZa(95.02, 100.0, 108.82)
         val SO2_F2 = ColorXYZa(98.09, 100.0, 67.53)
         val SO2_TL4 = ColorXYZa(101.40, 100.0, 65.90)
         val SO2_UL3000 = ColorXYZa(107.99, 100.0, 33.91)
         val SO2_D50 = ColorXYZa(107.99, 100.0, 82.45)
         val SO2_D60 = ColorXYZa(107.99, 100.0, 100.86)
+        val SO2_D65 = ColorXYZa(95.02, 100.0, 108.82)
         val SO2_D75 = ColorXYZa(107.99, 100.0, 122.53)
 
+        // White points of standard illuminants as per the CIE 1963 10° Standard Observer
         val SO10_A = ColorXYZa(111.16, 100.0, 35.19)
         val SO10_C = ColorXYZa(97.30, 100.0, 116.14)
-        val SO10_D65 = ColorXYZa(94.83, 100.0, 107.38)
         val SO10_F2 = ColorXYZa(102.12, 100.0, 69.37)
         val SO10_TL4 = ColorXYZa(103.82, 100.0, 66.90)
         val SO10_UL3000 = ColorXYZa(111.12, 100.0, 35.21)
         val SO10_D50 = ColorXYZa(96.72, 100.0, 81.45)
         val SO10_D60 = ColorXYZa(95.21, 100.0, 99.60)
+        val SO10_D65 = ColorXYZa(94.83, 100.0, 107.38)
         val SO10_D75 = ColorXYZa(94.45, 100.0, 120.70)
 
         val NEUTRAL = fromRGBa(ColorRGBa(1.0, 1.0, 1.0, linearity = Linearity.LINEAR))

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorYxya.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorYxya.kt
@@ -1,5 +1,13 @@
 package org.openrndr.color
 
+/**
+ * The Yxy color space, also known as the
+ * [xyY color space](https://en.wikipedia.org/wiki/CIE_1931_color_space#CIE_xy_chromaticity_diagram_and_the_CIE_xyY_color_space).
+ * @param yy luminance of the color, in a range of 0.0 (darkest) to 100.0 (brightest)
+ * @param x first chromaticity coordinate, in a range of 0.0 to 1.0
+ * @param y second chromaticity coordinate, in a range of 0.0 to 1.0
+ */
+@Suppress("LocalVariableName")
 data class ColorYxya(val yy: Double, val x: Double, val y: Double, val a: Double = 1.0) {
     companion object {
         fun fromXYZa(xyza: ColorXYZa): ColorYxya {


### PR DESCRIPTION
Also deprecates ColorATV.

Note: I can make the `mix` documentation have a single source of truth with an interface if there's demand. 👀 