### PR TITLE
Cubic segment of linear Segment3D

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Segment3D.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Segment3D.kt
@@ -241,6 +241,15 @@ class Segment3D {
                     end
                 )
             }
+            linear -> {
+                val delta = end - start
+                Segment3D(
+                    start,
+                    start + delta * (1.0 / 3.0),
+                    start + delta * (2.0 / 3.0),
+                    end
+                )
+            }
             else -> throw RuntimeException("cannot convert to cubic segment")
         }
 


### PR DESCRIPTION
For consistency with `Segment` and is useful e.g. for 3D Bézier patch using linear segments