### PR TITLE
SVG fixes

### DIFF
--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/shape/CompositionStyleSheet.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/shape/CompositionStyleSheet.kt
@@ -24,10 +24,10 @@ sealed interface Paint : AttributeOrPropertyValue {
 
     class RGB(override val value: ColorRGBa) : Paint {
         override fun toString(): String {
-            val ir = (value.r.coerceIn(0.0, 1.0) * 255.0).toInt().toString(16)
-            val ig = (value.g.coerceIn(0.0, 1.0) * 255.0).toInt().toString(16)
-            val ib = (value.b.coerceIn(0.0, 1.0) * 255.0).toInt().toString(16)
-            return ir + ig + ib
+            val hexs = listOf(value.r, value.g, value.b).map {
+                (it.coerceIn(0.0, 1.0) * 255.0).toInt().toString(16).padStart(2, '0')
+            }
+            return hexs.joinToString(prefix = "#", separator = "")
         }
     }
 
@@ -35,6 +35,7 @@ sealed interface Paint : AttributeOrPropertyValue {
     object CurrentColor : Paint {
         override val value: ColorRGBa
             get() = TODO("Not yet implemented")
+
         override fun toString(): String = "currentcolor"
     }
 

--- a/openrndr-svg/src/jvmTest/kotlin/TestSVGWriter.kt
+++ b/openrndr-svg/src/jvmTest/kotlin/TestSVGWriter.kt
@@ -30,6 +30,11 @@ object TestSVGWriter : Spek({
                 circle(Vector2(100.0, 100.0), 50.0)?.id = "circle"
             }
         }
+        it("can serialize colors") {
+            val svgString = comp.toSVG()
+            // The shorthand hex color is just as valid
+            svgString `should contain some` listOf("fill=\"#ff0000\"", "fill=\"#f00\"")
+        }
         it("can be written and loaded") {
             val svgString = comp.toSVG()
             val loaded = loadSVG(svgString)


### PR DESCRIPTION
* Fix color serialization for Composition and add a test to verify the fix.

This addresses one half of the problem showcased in #245.