### PR TITLE
Fix Kinect support

### DIFF
--- a/openrndr-application/src/jvmMain/kotlin/org/openrndr/ResourceUrl.kt
+++ b/openrndr-application/src/jvmMain/kotlin/org/openrndr/ResourceUrl.kt
@@ -4,7 +4,7 @@ import java.net.URL
 import kotlin.reflect.KClass
 
 actual fun resourceUrl(name: String, `class`: KClass<*>): String {
-    val resource = `class`::class.java.getResource(name)
+    val resource = `class`.java.getResource(name)
     if (resource == null) {
         throw RuntimeException("resource $name not found")
     } else {


### PR DESCRIPTION
This PR fixes: https://github.com/openrndr/openrndr/issues/264
Co-authored-by: Kazik Pogoda <morisil@xemantic.com>

The definition of the interface for `resourceUrl` (or rather its default argument) suggests that the argument is a class: 
https://github.com/openrndr/openrndr/blob/f1ccaf46e53e0f9dc682565b39b41fcbf1a61c62/openrndr-application/src/commonMain/kotlin/org/openrndr/ResourceUrl.kt#L7

so accessing a class of that argument in the JVM implementation of `resourceUrl` is wrong. 

In case of Kinect integration (the bug issued in https://github.com/openrndr/openrndr/issues/264), the shader file was intended to be found in the path relative to `DefaultKinects` class [(link to the the orx project)](https://github.com/openrndr/orx/blob/bae1f071c4965c680111a81fbb5c6e9fae407763/orx-jvm/orx-kinect-common/src/main/kotlin/org/openrndr/extra/kinect/impl/KinectImpl.kt#L142-L145)
```
resourceUrl(
    "kinect-raw-to-depth.frag",
    DefaultKinects::class
)
```
Instead, it was searched for in a path relative to `DefaultKinects::class::class` - and never found there, hence the `RuntimeException`.

I tested this code with orx project built from master branch, with a Kinect device connected to my machine. The Kinect example from the OPENRNDR Guide works :+1: 