### PR TITLE
add exr compressions to saveToFile, fix colour components order

### DIFF
--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ColorBufferGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ColorBufferGL3.kt
@@ -46,6 +46,19 @@ enum class TextureStorageModeGL {
     STORAGE
 }
 
+/**
+ * Exposes TINYEXR_COMPRESSIONTYPE for convention
+ */
+enum class ExrCompression(val value: Int) {
+   NONE(TINYEXR_COMPRESSIONTYPE_NONE),
+   RLE(TINYEXR_COMPRESSIONTYPE_RLE),
+   ZIPS(TINYEXR_COMPRESSIONTYPE_ZIPS),
+   ZIP(TINYEXR_COMPRESSIONTYPE_ZIP),
+   PIZ(TINYEXR_COMPRESSIONTYPE_PIZ),
+   ZFP(TINYEXR_COMPRESSIONTYPE_ZFP)  // experimental, see https://tinyexr.docsforge.com/master/getting-started/#zfp
+}
+
+
 internal fun internalFormat(format: ColorFormat, type: ColorType): Pair<Int, Int> {
     val entries = arrayOf(
         ConversionEntry(ColorFormat.R, ColorType.UINT8, GL_R8, GL_RED),
@@ -135,6 +148,7 @@ class ColorBufferGL3(
     override val session: Session?
 ) : ColorBuffer() {
 
+    var exrCompression = ExrCompression.NONE
 
     private var destroyed = false
     override var flipV: Boolean = false
@@ -874,6 +888,9 @@ class ColorBufferGL3(
                 InitEXRHeader(exrHeader)
 
                 exrHeader.num_channels(3)
+                if (exrCompression != ExrCompression.NONE) {
+                    exrHeader.compression_type(exrCompression.value)
+                }
 
                 val exrChannels = EXRChannelInfo.calloc(3)
                 exrChannels[0].name(
@@ -909,18 +926,18 @@ class ColorBufferGL3(
 
                     for (x in 0 until effectiveWidth) {
                         for (i in 0 until type.componentSize) {
-                            val b = data.get()
-                            bBuffer.put(b)
+                            val r = data.get()
+                            rBuffer.put(r)
                         }
                         for (i in 0 until type.componentSize) {
                             val g = data.get()
                             gBuffer.put(g)
                         }
                         for (i in 0 until type.componentSize) {
-                            val r = data.get()
-                            rBuffer.put(r)
+                            val b = data.get()
+                            bBuffer.put(b)
                         }
-                    }
+                   }
                 }
 
                 (bBuffer as Buffer).rewind()

--- a/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestEXRSaverWithCompression.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestEXRSaverWithCompression.kt
@@ -1,0 +1,207 @@
+import kotlin.test.Test
+
+import org.openrndr.application
+import org.openrndr.draw.ColorBuffer
+import org.openrndr.draw.ColorFormat
+import org.openrndr.draw.ColorType
+import org.openrndr.draw.colorBuffer
+import org.openrndr.internal.gl3.ColorBufferGL3
+import org.openrndr.internal.gl3.ExrCompression
+import java.io.File
+import kotlin.test.Ignore
+
+class TestEXRSaverWithCompression {
+
+    @Test
+    fun testSaveExrRGBa16WithRLECompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.RLE
+                cb.saveToFile(File("exr16a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB16WithRLECompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.RLE
+                cb.saveToFile(File("exr16.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB32WithRLECompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.RLE
+                cb.saveToFile(File("exr32.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa32WithRLECompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.RLE
+                cb.saveToFile(File("exr32a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa16WithZIPCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIP
+                cb.saveToFile(File("exr16a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB16WithZIPCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIP
+                cb.saveToFile(File("exr16.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa32WithZIPCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIP
+                cb.saveToFile(File("exr32a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB32WithZIPCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIP
+                cb.saveToFile(File("exr32.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa16WithZIPSCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIPS
+                cb.saveToFile(File("exr16a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB16WithZIPSCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIPS
+                cb.saveToFile(File("exr16.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa32WithZIPSCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIPS
+                cb.saveToFile(File("exr32a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB32WithZIPSCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.ZIPS
+                cb.saveToFile(File("exr32.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa16WithPIZCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.PIZ
+                cb.saveToFile(File("exr16a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB16WithPIZCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT16)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.PIZ
+                cb.saveToFile(File("exr16.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGBa32WithPIZCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGBa, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.PIZ
+                cb.saveToFile(File("exr32a.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+    @Test
+    fun testSaveExrRGB32WithPIZCompression() {
+        application {
+            program {
+                val cb = colorBuffer(512, 512, format = ColorFormat.RGB, type = ColorType.FLOAT32)
+                (cb as ColorBufferGL3).exrCompression = ExrCompression.PIZ
+                cb.saveToFile(File("exr32.exr"), async = false)
+                application.exit()
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This commit propose exhancement to saving EXR files. I avoided changing signature of abstract method in superclass and instead propose new public property in jvm class implementation. It is not ideal for user, but this commit is open for discussion and critic and call for better design is highly welcomed. Also, there is a bug in colour data transfer to ByteBuffers and it seems that red and blue channel are swapped in a final exr file. 