### PR TITLE
 [openrndr-draw] Make loadImageSuspend use createColorBufferFromUrlSuspend

### DIFF
--- a/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/ColorBuffer.kt
+++ b/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/ColorBuffer.kt
@@ -184,5 +184,5 @@ actual suspend fun loadImageSuspend(
     formatHint: ImageFileFormat?,
     session: Session?
 ): ColorBuffer {
-    return Driver.instance.createColorBufferFromUrl(fileOrUrl, null, session)
+    return Driver.instance.createColorBufferFromUrlSuspend(fileOrUrl, null, session)
 }


### PR DESCRIPTION
Necessary for image loading in the browser to work