### PR TITLE
Delay PreloadClass so ScreenRecorder can be preloaded successfully

### DIFF
--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ApplicationEGLGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ApplicationEGLGL3.kt
@@ -114,6 +114,9 @@ class ApplicationEGLGL3(private val program: Program, private val configuration:
 
             val defaultRenderTarget = ProgramRenderTargetGL3(program)
             defaultRenderTarget.bind()
+
+            setupPreload(program, configuration)
+
             program.drawer = Drawer(driver)
             runBlocking {
                 program.setup()

--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ApplicationGLFWGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ApplicationGLFWGL3.kt
@@ -516,6 +516,7 @@ class ApplicationGLFWGL3(private val program: Program, private val configuration
         defaultRenderTarget.bind()
 
         setupSizes()
+        setupPreload(program, configuration)
         program.drawer.ortho()
     }
 

--- a/openrndr-nullgl/src/main/kotlin/ApplicationNullGL.kt
+++ b/openrndr-nullgl/src/main/kotlin/ApplicationNullGL.kt
@@ -19,6 +19,7 @@ class ApplicationNullGL(private val program: Program, private val configuration:
     init {
         Driver.driver = DriverNullGL()
         program.application = this
+        setupPreload(program, configuration)
     }
 
     override fun requestDraw() {


### PR DESCRIPTION
The previous behavior preloaded the class before window
width and height were known which made ScreenRecorder fail.