### PR TITLE
Fix #123 - Re-add default font

### DIFF
--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/Drawer.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/Drawer.kt
@@ -79,17 +79,6 @@ class Drawer(val driver: Driver) {
     private var qualityPolygonDrawer = QualityPolygonDrawer()
     val fontImageMapDrawer = FontImageMapDrawer()
 
-//    private val defaultFontMap by lazy {
-//        val defaultFontPath = File("data/fonts/default.otf")
-//        if (defaultFontPath.isFile) {
-//            logger.info("loading default font from ${defaultFontPath.absolutePath}")
-//            org.openrndr.draw.loadFont(defaultFontPath.path, 16.0)
-//        } else {
-//            logger.warn("default font ${defaultFontPath.absolutePath} not found")
-//            null
-//        }
-//    }
-
     private val modelStack = ArrayDeque<Matrix44>()
     private val viewStack = ArrayDeque<Matrix44>()
     private val projectionStack = ArrayDeque<Matrix44>()
@@ -469,7 +458,7 @@ class Drawer(val driver: Driver) {
         }
         get() {
             if (drawStyle.fontMap == null) {
-                //drawStyle.fontMap = defaultFontMap
+                drawStyle.fontMap = defaultFontMap
             }
             return drawStyle.fontMap
         }

--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/FontMap.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/FontMap.kt
@@ -36,6 +36,8 @@ abstract class FontMap {
     abstract val name: String
 }
 
+expect val defaultFontMap: FontImageMap?
+
 data class GlyphMetrics(val advanceWidth: Double, val leftSideBearing: Double, val xBitmapShift: Double, val yBitmapShift: Double)
 
 data class FontImageMapDescriptor(val fontUrl: String, val size: Double, val alphabet:Set<Char>, val contentScale: Double)
@@ -92,3 +94,4 @@ abstract class FontVectorMap : FontMap() {
         }
     }
 }
+

--- a/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/FontMap.kt
+++ b/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/FontMap.kt
@@ -1,0 +1,5 @@
+package org.openrndr.draw
+
+actual val defaultFontMap: FontImageMap? by lazy {
+    null
+}

--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/FontMap.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/FontMap.kt
@@ -1,9 +1,12 @@
 @file:JvmName("FontMapJVM")
 package org.openrndr.draw
 
+import mu.KotlinLogging
 import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
+
+private val logger = KotlinLogging.logger {}
 
 fun loadFont(fileOrUrl: String, size: Double, characterSet: Set<Char> = defaultFontmapCharacterSet, contentScale: Double = 1.0): FontImageMap {
     val activeSet = if (characterSet.contains(' ')) characterSet else (characterSet + ' ')
@@ -15,9 +18,20 @@ fun loadFont(fileOrUrl: String, size: Double, characterSet: Set<Char> = defaultF
         require(file.exists()) {
             "failed to load font: file '${file.absolutePath}' does not exist."
         }
-        require(file.extension.toLowerCase() in setOf("ttf", "otf")) {
+        require(file.extension.lowercase() in setOf("ttf", "otf")) {
             "failed to load font: file '${file.absolutePath}' is not a .ttf or .otf file"
         }
         FontImageMap.fromFile(fileOrUrl, size, activeSet, contentScale)
+    }
+}
+
+actual val defaultFontMap by lazy {
+    val defaultFontPath = File("data/fonts/default.otf")
+    if (defaultFontPath.isFile) {
+        logger.info("loading default font from ${defaultFontPath.absolutePath}")
+        loadFont(defaultFontPath.path, 16.0)
+    } else {
+        logger.warn("default font ${defaultFontPath.absolutePath} not found")
+        null
     }
 }


### PR DESCRIPTION
Default font is provided in JVM only. In JS the fontMap stays null (unchanged).

This is my first commit dealing with "multiplatformness". Review welcome.