### PR TITLE
Cache artifex conversions so that operations like contains can re-use them

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Shape.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Shape.kt
@@ -2,6 +2,8 @@
 
 package org.openrndr.shape
 
+import org.openrndr.kartifex.Path2
+import org.openrndr.kartifex.Region2
 import org.openrndr.math.*
 import org.openrndr.utils.resettableLazy
 import kotlin.random.Random
@@ -107,10 +109,25 @@ class Shape(val contours: List<ShapeContour>) : ShapeProvider {
     /** Calculates approximate area for this shape (through triangulation). */
     val area by areaDelegate
 
+    private val region2Delegate = resettableLazy {
+        Region2(contours.map { it.ring2 })
+    }
+
+    internal val region2 by region2Delegate
+
+    private val path2Delegate = resettableLazy {
+        contours.map { it.path2 }
+    }
+
+    internal val path2 by path2Delegate
+
     fun resetCache() {
         boundsDelegate.reset()
         triangulationDelegate.reset()
         areaDelegate.reset()
+        region2Delegate.reset()
+        path2Delegate.reset()
+        contours.forEach { it.resetCache() }
     }
 
     /**

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
@@ -1,6 +1,9 @@
 package org.openrndr.shape
 
+import org.openrndr.kartifex.Path2
+import org.openrndr.kartifex.Ring2
 import org.openrndr.math.*
+import org.openrndr.utils.resettableLazy
 import kotlin.jvm.JvmOverloads
 import kotlin.math.abs
 import kotlin.math.min
@@ -596,6 +599,23 @@ data class ShapeContour @JvmOverloads constructor (
         )
     override val contour: ShapeContour
         get() = this
+
+    private val path2Delegate = resettableLazy {
+        Path2(segments.map { it.toCurve2() })
+    }
+
+    internal val path2 by path2Delegate
+
+    private val ring2Delegate = resettableLazy {
+        Ring2(segments.map { it.toCurve2() })
+    }
+
+    internal val ring2 by ring2Delegate
+
+    fun resetCache() {
+        path2Delegate.reset()
+        ring2Delegate.reset()
+    }
 }
 
 /**

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContourExtensions.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContourExtensions.kt
@@ -5,7 +5,7 @@ import org.openrndr.math.Vector2
 import kotlin.math.sqrt
 
 /** Returns true if given [point] lies inside the [ShapeContour]. */
-operator fun ShapeContour.contains(point: Vector2): Boolean = closed && this.toRing2().test(
+operator fun ShapeContour.contains(point: Vector2): Boolean = closed && this.ring2.test(
     Vec2(point.x, point.y)
 ).inside
 

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeExtensions.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeExtensions.kt
@@ -27,5 +27,5 @@ operator fun Shape.contains(v: Vector2): Boolean {
     if (empty) {
         return false
     }
-    return toRegion2().contains(Vec2(v.x, v.y))
+    return region2.contains(Vec2(v.x, v.y))
 }


### PR DESCRIPTION
ShapeContour::contains was taking over 90% of my profiled runtime, with this it's under 10%