### PR TITLE
Begin renaming configuration to buildConfiguration

### DIFF
--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/Configuration.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/Configuration.kt
@@ -171,9 +171,16 @@ class Configuration {
 
 }
 
+@Deprecated(
+    "Use buildConfiguration instead", level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith("buildConfiguration(builder)")
+)
+fun configuration(builder: Configuration.() -> Unit): Configuration = buildConfiguration(builder)
+
 /**
- * Simple configuration builder
+ * Convenience function for building a new [Configuration].
+ * @return the built [Configuration]
  */
-fun configuration(builder: Configuration.() -> Unit): Configuration {
+fun buildConfiguration(builder: Configuration.() -> Unit): Configuration {
     return Configuration().apply(builder)
 }


### PR DESCRIPTION
Adds `buildConfiguration` and a deprecation warning to `configuration`. The old method can be completely removed in the future.