### PR TITLE
Add TransformBuilder.rotate(Double)

### DIFF
--- a/openrndr-math/src/commonMain/kotlin/org/openrndr/math/transforms/TransformBuilder.kt
+++ b/openrndr-math/src/commonMain/kotlin/org/openrndr/math/transforms/TransformBuilder.kt
@@ -10,6 +10,8 @@ import kotlin.reflect.KMutableProperty0
 class TransformBuilder(baseTransform: Matrix44 = Matrix44.IDENTITY) {
     var transform: Matrix44 = baseTransform
 
+    fun rotate(degrees: Double) = rotate(Vector3.UNIT_Z, degrees)
+
     fun rotate(axis: Quaternion) {
         transform *= axis.matrix.matrix44
     }


### PR DESCRIPTION
This method signature was missing, which made it harder to convert a series of `drawer.translate/rotate/scale` into a  transformation to applying later.

`drawer.rotate(degrees)` existed but one could not do `transform { rotate(degrees) }` without specifying the axis or using a named argument.

In some situations one might even end up calling `drawer.rotate()` unknowingly.