### PR TITLE
Remove ApplicationDslMarker

### DIFF
--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/Application.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/Application.kt
@@ -19,9 +19,6 @@ enum class PresentationMode {
     MANUAL,
 }
 
-@DslMarker
-annotation class ApplicationDslMarker
-
 /**
  * Application interface
  */

--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/ApplicationBuilder.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/ApplicationBuilder.kt
@@ -1,6 +1,5 @@
 package org.openrndr
 
-@ApplicationDslMarker
 expect class ApplicationBuilder internal constructor(){
     internal val configuration: Configuration
     var program: Program

--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/Configuration.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/Configuration.kt
@@ -46,7 +46,6 @@ sealed class WindowMultisample {
     data class SampleCount(val count: Int) : WindowMultisample()
 }
 
-@ApplicationDslMarker
 class Configuration {
 
     var canvasId = "openrndr-canvas"

--- a/openrndr-application/src/jsMain/kotlin/org/openrndr/ApplicationBuilder.kt
+++ b/openrndr-application/src/jsMain/kotlin/org/openrndr/ApplicationBuilder.kt
@@ -20,7 +20,6 @@ actual suspend fun applicationAsync(build: ApplicationBuilder.() -> Unit) {
 }
 
 @Suppress("DeprecatedCallableAddReplaceWith")
-@ApplicationDslMarker
 actual class ApplicationBuilder internal actual constructor() {
     internal actual val configuration = Configuration()
     actual var program: Program = Program()

--- a/openrndr-application/src/jvmMain/kotlin/org/openrndr/ApplicationBuilder.kt
+++ b/openrndr-application/src/jvmMain/kotlin/org/openrndr/ApplicationBuilder.kt
@@ -95,7 +95,6 @@ actual suspend fun applicationAsync(build: ApplicationBuilder.() -> Unit) {
 }
 
 @Suppress("DeprecatedCallableAddReplaceWith")
-@ApplicationDslMarker
 actual class ApplicationBuilder internal actual constructor() {
     internal actual val configuration = Configuration()
     actual var program: Program = Program()

--- a/openrndr-demos/src/main/kotlin/DemoDisplayQuery01.kt
+++ b/openrndr-demos/src/main/kotlin/DemoDisplayQuery01.kt
@@ -1,0 +1,19 @@
+import org.openrndr.application
+
+/**
+ * Demonstrates querying and using displays.
+ */
+fun main() {
+    application {
+        configure {
+            // First detected display, most likely your primary display.
+            display = displays[0]
+            width = 800
+            height = 800
+        }
+
+        program {
+            extend {}
+        }
+    }
+}

--- a/openrndr-demos/src/main/kotlin/DemoDisplayQuery02.kt
+++ b/openrndr-demos/src/main/kotlin/DemoDisplayQuery02.kt
@@ -1,0 +1,21 @@
+import org.openrndr.application
+
+/**
+ * Demonstrates querying and using displays.
+ */
+fun main() {
+    application {
+        // Find the display with the largest resolution from the list of detected displays.
+        val biggestDisplay = displays.maxByOrNull { it.width!! * it.height!! }!!
+
+        configure {
+            display = biggestDisplay
+            width = 800
+            height = 800
+        }
+
+        program {
+            extend {}
+        }
+    }
+}


### PR DESCRIPTION
I noticed you currently can't actually write
```kotlin
application {
    configure {
        display = displays[0]
    }
}
```
because you're trying to access `displays` inside the scope of `configure` not `application`. A workaround would be to write `display = this@application.displays[0]` but that's not pleasant. Instead it's easier to remove ApplicationDslMarker entirely.