### PR TITLE
fix vertexbuffer calls at non-zero offsets in javascript

### DIFF
--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/VertexBufferShadow.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/VertexBufferShadow.kt
@@ -2,7 +2,7 @@ package org.openrndr.draw
 
 interface VertexBufferShadow {
     val vertexBuffer: VertexBuffer
-    fun upload(offset: Int = 0, size: Int = vertexBuffer.vertexCount * vertexBuffer.vertexFormat.size)
+    fun upload(offsetInBytes: Int = 0, sizeInBytes: Int = vertexBuffer.vertexCount * vertexBuffer.vertexFormat.size)
     fun uploadElements(elementOffset: Int = 0, elementCount: Int = vertexBuffer.vertexCount) {
         upload(elementOffset * vertexBuffer.vertexFormat.size, elementCount * vertexBuffer.vertexFormat.size)
     }

--- a/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/BufferWriter.kt
+++ b/openrndr-draw/src/jsMain/kotlin/org/openrndr/draw/BufferWriter.kt
@@ -27,8 +27,15 @@ actual abstract class BufferWriter {
      * rewind the underlying buffer
      */
     actual abstract fun rewind()
+
+    /**
+     * Set the raw position of the underlying buffer, in 4-byte strides
+     */
     actual abstract var position: Int
+
+    /**
+     * Set the position of the underlying buffer to accommodate the given number of elements
+     * according to the format size
+     */
     actual abstract var positionElements: Int
-
-
 }

--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/BufferWriter.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/BufferWriter.kt
@@ -32,8 +32,15 @@ actual abstract class BufferWriter {
      * rewind the underlying buffer
      */
     actual abstract fun rewind()
+
+    /**
+     * Set the raw position of the underlying buffer, in bytes
+     */
     actual abstract var position: Int
+
+    /**
+     * Set the position of the underlying buffer to accommodate the given number of elements
+     * according to the format size
+     */
     actual abstract var positionElements: Int
-
-
 }

--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/VertexBuffer.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/VertexBuffer.kt
@@ -34,7 +34,7 @@ actual abstract class VertexBuffer {
         w.positionElements = elementOffset
         w.putter()
         if (w.position % vertexFormat.size != 0) {
-            throw RuntimeException("incomplete vertices written. likely violating the specified vertex format $vertexFormat")
+            throw RuntimeException("incomplete vertices written at ${w.position}. likely violating the specified vertex format $vertexFormat")
         }
         val count = w.positionElements - elementOffset
         shadow.uploadElements(elementOffset, count)

--- a/openrndr-js/openrndr-webgl/src/jsMain/kotlin/org/openrndr/webgl/BufferWriterWebGL.kt
+++ b/openrndr-js/openrndr-webgl/src/jsMain/kotlin/org/openrndr/webgl/BufferWriterWebGL.kt
@@ -7,6 +7,9 @@ import org.openrndr.draw.BufferWriter
 import org.openrndr.math.*
 
 class BufferWriterWebGL(val buffer: Float32Array, val elementSize: Int): BufferWriter() {
+    init {
+        require(elementSize % 4 == 0) { "elementSize $elementSize must be a multiple of 4" }
+    }
 
     override var position: Int = 0
 

--- a/openrndr-js/openrndr-webgl/src/jsMain/kotlin/org/openrndr/webgl/VertexBufferWebGL.kt
+++ b/openrndr-js/openrndr-webgl/src/jsMain/kotlin/org/openrndr/webgl/VertexBufferWebGL.kt
@@ -11,8 +11,8 @@ class VertexBufferShadowWebGL(override val vertexBuffer: VertexBuffer) : VertexB
 
     val shadow = Float32Array(vertexBuffer.vertexCount * (vertexBuffer.vertexFormat.size / 4))
 
-    override fun upload(offset: Int, size: Int) {
-        vertexBuffer.write(shadow, 0, size/4)
+    override fun upload(offsetInBytes: Int, sizeInBytes: Int) {
+        vertexBuffer.write(shadow, offsetInBytes, sizeInBytes / 4)
     }
 
     override fun download() {
@@ -73,15 +73,17 @@ class VertexBufferWebGL(
         Session.active.untrack(this)
     }
 
-    override fun write(data: FloatArray, offset:Int, floatCount:Int) {
+    override fun write(data: FloatArray, offsetBytes:Int, floatCount:Int) {
         bind()
-        context.bufferSubData(GL.ARRAY_BUFFER, offset, Float32Array(data.toTypedArray()).subarray(0, floatCount))
+        val offsetFloats = offsetBytes / 4
+        context.bufferSubData(GL.ARRAY_BUFFER, offsetBytes, Float32Array(data.toTypedArray()).subarray(offsetFloats, offsetFloats + floatCount))
         unbind()
     }
 
-    override fun write(data: Float32Array, offset:Int, floatCount: Int) {
+    override fun write(data: Float32Array, offsetBytes:Int, floatCount: Int) {
         bind()
-        context.bufferSubData(GL.ARRAY_BUFFER, offset, data.subarray(0, floatCount))
+        val offsetFloats = offsetBytes / 4
+        context.bufferSubData(GL.ARRAY_BUFFER, offsetBytes, data.subarray(offsetFloats, offsetFloats + floatCount))
         unbind()
     }
 

--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/VertexBufferGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/VertexBufferGL3.kt
@@ -26,11 +26,11 @@ class VertexBufferShadowGL3(override val vertexBuffer: VertexBufferGL3) : Vertex
                 logger.debug { "${vertexBuffer}" }
             }
 
-    override fun upload(offset: Int, size: Int) {
+    override fun upload(offsetInBytes: Int, sizeInBytes: Int) {
         logger.trace { "uploading shadow to vertex buffer" }
         (buffer as Buffer).rewind()
-        (buffer as Buffer).position(offset)
-        (buffer as Buffer).limit(offset + size)
+        (buffer as Buffer).position(offsetInBytes)
+        (buffer as Buffer).limit(offsetInBytes + sizeInBytes)
         vertexBuffer.write(buffer)
         (buffer as Buffer).limit(buffer.capacity())
     }

--- a/openrndr-nullgl/src/main/kotlin/VertexBufferNullGL.kt
+++ b/openrndr-nullgl/src/main/kotlin/VertexBufferNullGL.kt
@@ -78,7 +78,7 @@ class BufferWriterNullGL : BufferWriter() {
 
 class VertexBufferShadowNullGL(override val vertexBuffer: VertexBuffer) : VertexBufferShadow {
 
-    override fun upload(offset: Int, size: Int) {
+    override fun upload(offsetInBytes: Int, sizeInBytes: Int) {
     }
 
     override fun download() {


### PR DESCRIPTION
the fixes are (1) to put() and (2) to write() where the subarray bounds were incorrect

the rest is some renaming and comments to try to make it easier to keep straight whether the Int in question represents a size in bytes or in floats