### PR TITLE
Remove inaccurate pointAtLength optimization

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Segment.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Segment.kt
@@ -176,7 +176,6 @@ class Segment : ShapeContourProvider {
         when {
             length <= 0.0 -> return start
             length >= this.length -> return end
-            isStraight(distanceTolerance) -> return start + (end - start) / this.length * length
         }
         var remainingLength = length
         var currentPoint = start

--- a/openrndr-shape/src/commonTest/kotlin/SegmentTest.kt
+++ b/openrndr-shape/src/commonTest/kotlin/SegmentTest.kt
@@ -12,17 +12,5 @@ class SegmentTest {
         assertEquals(Vector2(162.22564697265625, 170.3757781982422), curve.pointAtLength(120.0, 0.0001), 0.0005)
         assertEquals(curve.start, curve.pointAtLength(-500.0, 0.0001))
         assertEquals(curve.end, curve.pointAtLength(500.0, 0.0001))
-
-        val perceivablyStraightCurve = Segment(
-            Vector2(110.0, 150.0),
-            arrayOf(Vector2(113.2009319983224, 146.1588936020131), Vector2(186.8221279597376, 57.81343644831489)),
-            Vector2(210.0, 30.0)
-        )
-        assertEquals(
-            Vector2(113.2009219983224, 146.1588936020131), perceivablyStraightCurve.pointAtLength(5.0), 1e-12
-        )
-        assertEquals(
-            Vector2(186.8221279597376, 57.81344644831489), perceivablyStraightCurve.pointAtLength(120.0), 1e-12
-        )
     }
 }


### PR DESCRIPTION
While this optimization may have resulted in better performance, the distanceTolerance for isStraight isn't equivalent, leading to worse pointAtLength accuracy than one would expect.