### PR TITLE
Use Gradle cache in Github Actions

### DIFF
--- a/.github/workflows/build-on-commit.yml
+++ b/.github/workflows/build-on-commit.yml
@@ -1,12 +1,25 @@
 name: Build on commit
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - name: Checkout current repository
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1.0.4
+
+      - uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: 17
-      - name: Build sources
+          cache: gradle
+
+      - name: Build OPENRNDR
         run: ./gradlew build

--- a/.github/workflows/release-apidocs.yml
+++ b/.github/workflows/release-apidocs.yml
@@ -3,17 +3,24 @@ on:
   push:
     branches:
       - master
+
 jobs:
-  build:
+  release_apidocs:
     if: github.repository == 'openrndr/openrndr'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - name: Checkout current repository
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: 17
+          cache: gradle
+
       - name: Build apidocs
         run: ./gradlew dokkaHtmlMultiModule -Dorg.gradle.jvmargs=-Xmx1536M
+
       - name: Publish to gh-pages
         run: |
           git worktree add --detach docs-temp

--- a/.github/workflows/release-candidate-to-maven-central.yml
+++ b/.github/workflows/release-candidate-to-maven-central.yml
@@ -3,16 +3,18 @@ on:
   push:
     tags:
       - v[0-9].[0-9]+.[0-9]+-rc.[0-9]+
+
 jobs:
-  build:
-    runs-on: ubuntu-18.04
+  release_candidate_to_maven_central:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: 17
       - name: Build and publish to local maven
         run: ./gradlew -Prelease.useLastTag=true build

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -3,16 +3,18 @@ on:
   push:
     tags:
       - v[0-9].[0-9]+.[0-9]+
+
 jobs:
-  build:
-    runs-on: ubuntu-18.04
+  release_to_maven_central:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: 17
       - name: Build and publish to local maven
         run: ./gradlew -Prelease.useLastTag=true build


### PR DESCRIPTION
Also uses latest Ubuntu and updates actions to latest versions. It doesn't necessarily have to be an 8 minute build every time.