### PR TITLE
ColorHSVa and ColorHSLa fixes

### DIFF
--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSVa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorHSVa.kt
@@ -30,54 +30,34 @@ data class ColorHSVa @JvmOverloads constructor (val h: Double, val s: Double, va
     companion object {
         fun fromRGBa(rgb: ColorRGBa): ColorHSVa {
             val srgb = rgb.toSRGB()
-            var min = Double.POSITIVE_INFINITY
-            var max = Double.NEGATIVE_INFINITY
+            val min = srgb.minValue
 
-            var h: Double
-            var maxArg: ColorRGBa.Component? = null
-
-            if (srgb.r <= srgb.b && srgb.r <= srgb.g) {
-                min = srgb.r
-            }
-            if (srgb.g <= srgb.b && srgb.g <= srgb.r) {
-                min = srgb.g
-            }
-            if (srgb.b <= srgb.r && srgb.b <= srgb.g) {
-                min = srgb.b
-            }
+            val max: Double
+            val maxArg: ColorRGBa.Component
 
             if (srgb.r >= srgb.b && srgb.r >= srgb.g) {
                 maxArg = ColorRGBa.Component.R
                 max = srgb.r
-            }
-            if (srgb.g >= srgb.b && srgb.g >= srgb.r) {
+            } else if (srgb.g >= srgb.b && srgb.g >= srgb.r) {
                 maxArg = ColorRGBa.Component.G
                 max = srgb.g
-            }
-            if (srgb.b >= srgb.r && srgb.b >= srgb.g) {
+            } else {
                 maxArg = ColorRGBa.Component.B
                 max = srgb.b
             }
 
-            val s: Double
             val v = max
+            // In the case r == g == b
+            if (min == max) {
+                return ColorHSVa(0.0, 0.0, v, srgb.alpha)
+            }
             val delta = max - min
-            if (max != 0.0) {
-                s = delta / max
-            } else {
-                // r = g = b = 0		// s = 0, v is undefined
-                s = 0.0
-                h = 0.0
-                return ColorHSVa(h, s, v, srgb.alpha)
+            val s = delta / max
+            var h = 60 * when (maxArg) {
+                ColorRGBa.Component.R -> (srgb.g - srgb.b) / delta // between yellow & magenta
+                ColorRGBa.Component.G -> (srgb.b - srgb.r) / delta + 2.0 // between cyan & yellow
+                ColorRGBa.Component.B -> (srgb.r - srgb.g) / delta + 4.0 // between magenta & cyan
             }
-            if (maxArg == ColorRGBa.Component.R) {
-                h = (srgb.g - srgb.b) / delta        // between yellow & magenta
-            } else if (maxArg == ColorRGBa.Component.G) {
-                h = 2 + (srgb.b - srgb.r) / delta    // between cyan & yellow
-            } else {
-                h = 4 + (srgb.r - srgb.g) / delta    // between magenta & cyan
-            }
-            h *= 60.0                // degrees
             if (h < 0) {
                 h += 360.0
             }

--- a/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorRGBa.kt
+++ b/openrndr-color/src/commonMain/kotlin/org/openrndr/color/ColorRGBa.kt
@@ -63,8 +63,7 @@ data class ColorRGBa @JvmOverloads constructor(
     enum class Component {
         R,
         G,
-        B,
-        Alpha
+        B
     }
 
     companion object {

--- a/openrndr-color/src/commonTest/kotlin/org/openrndr/color/ColorHSLaTest.kt
+++ b/openrndr-color/src/commonTest/kotlin/org/openrndr/color/ColorHSLaTest.kt
@@ -1,0 +1,14 @@
+package org.openrndr.color
+
+import kotlin.test.*
+
+class ColorHSLaTest {
+    @Test
+    fun grayscaleToHSLA() {
+        val gray = ColorRGBa(0.3, 0.3, 0.3, 1.0, Linearity.SRGB)
+        val components = gray.toHSLa().toVector4().toDoubleArray()
+        for (component in components) {
+            assertTrue(component.isFinite())
+        }
+    }
+}

--- a/openrndr-color/src/commonTest/kotlin/org/openrndr/color/ColorHSVaTest.kt
+++ b/openrndr-color/src/commonTest/kotlin/org/openrndr/color/ColorHSVaTest.kt
@@ -1,0 +1,14 @@
+package org.openrndr.color
+
+import kotlin.test.*
+
+class ColorHSVaTest {
+    @Test
+    fun grayscaleToHSVA() {
+        val gray = ColorRGBa(0.3, 0.3, 0.3, 1.0, Linearity.SRGB)
+        val components = gray.toHSVa().toVector4().toDoubleArray()
+        for (component in components) {
+            assertTrue(component.isFinite())
+        }
+    }
+}


### PR DESCRIPTION
Simplifies ColorRGBa to ColorHSVa and ColorHSLa conversion code.
This also includes the following fixes:
* ColorHSVa.fromRGBa will no longer return NaN for `h` for a grayscale ColorRGBa
* ColorHSLa#toRGBa will always return a ColorRGBa in sRGB linearity

One potentially controversial change is the removal of ColorRGBa.Component.Alpha. Given that ColorRGBa.Component is only ever used for ColorHSLa and ColorHSVa and even they never make use of the Alpha leads me to believe ColorRGBa.Component is better off having strictly color components. This change helps simplify the ColorHSVa and ColorHSLa conversion code.