### PR TITLE
Add missing dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-jvm.gradle.kts
@@ -19,8 +19,8 @@ repositories {
 group = "org.openrndr"
 
 dependencies {
-    implementation(libs.kotlin.logging)
     implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.logging)
     testImplementation(libs.kotlin.test)
 }
 
@@ -44,5 +44,6 @@ tasks {
     }
     withType<KotlinCompile>() {
         kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
+        kotlinOptions.languageVersion = libs.versions.kotlinLanguage.get()
     }
 }

--- a/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-multiplatform.gradle.kts
@@ -19,6 +19,7 @@ group = "org.openrndr"
 
 tasks.withType<KotlinCompile>() {
     kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
+    kotlinOptions.languageVersion = libs.versions.kotlinLanguage.get()
 }
 
 kotlin {
@@ -41,6 +42,7 @@ kotlin {
         @Suppress("UNUSED_VARIABLE")
         val commonMain by getting {
             dependencies {
+                implementation(libs.kotlin.stdlib)
                 implementation(libs.kotlin.logging)
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,11 @@ org.gradle.jvmargs=-Xmx2G -XX:+UseParallelGC
 # Enable compatibility with non-hierarchical projects
 # https://kotlinlang.org/docs/multiplatform-hierarchy.html#for-library-authors
 kotlin.mpp.enableCompatibilityMetadataVariant=true
-kotlin.js.compiler=both
 kotlin.incremental.multiplatform=true
 # https://kotlinlang.org/docs/gradle.html#check-for-jvm-target-compatibility-of-related-compile-tasks
 kotlin.jvm.target.validation.mode=error
 org.gradle.parallel=true
 org.gradle.caching=true
+# Whether to automatically bundle the Kotlin standard library (true by default)
+# https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=true

--- a/openrndr-dds/build.gradle.kts
+++ b/openrndr-dds/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
                 implementation(project(":openrndr-math"))
                 implementation(project(":openrndr-draw"))
                 implementation(project(":openrndr-utils"))
+                implementation(libs.kotlin.coroutines)
             }
         }
     }

--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/internal/FontImageMapDrawer.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/internal/FontImageMapDrawer.kt
@@ -44,7 +44,8 @@ class FontImageMapDrawer {
 
             var instance = 0
 
-            for ((text, position) in (texts zip positions)) {
+            val textAndPositionPairs = texts.zip(positions)
+            for ((text, position) in textAndPositionPairs) {
                 var cursorX = 0.0
                 val cursorY = 0.0
 

--- a/openrndr-js/openrndr-webgl/build.gradle.kts
+++ b/openrndr-js/openrndr-webgl/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
             dependencies {
                 api(project(":openrndr-application"))
                 api(project(":openrndr-draw"))
+                implementation(libs.kotlin.coroutines)
             }
         }
     }


### PR DESCRIPTION
Some modules were missing a dependency on kotlinx-coroutines. Also explicitly specify the kotlin language version for compilation. Add explicit dependency on kotlin-stdlib, regardless of whether kotlin gradle plugin already includes it for us.