### PR TITLE
[openrndr-math] Fix VectorN smoothstep bug

### DIFF
--- a/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Mapping.kt
+++ b/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Mapping.kt
@@ -127,18 +127,18 @@ fun Double.smoothstep(edge0: Double, edge1: Double) = smoothstep(edge0, edge1, t
 
 fun Vector2.smoothstep(edge0: Vector2, edge1: Vector2): Vector2 =
         Vector2(this.x.smoothstep(edge0.x, edge1.x),
-                this.x.smoothstep(edge0.y, edge1.y))
+                this.y.smoothstep(edge0.y, edge1.y))
 
 fun Vector3.smoothstep(edge0: Vector3, edge1: Vector3): Vector3 =
         Vector3(this.x.smoothstep(edge0.x, edge1.x),
-                this.x.smoothstep(edge0.y, edge1.y),
-                this.x.smoothstep(edge0.z, edge1.z))
+                this.y.smoothstep(edge0.y, edge1.y),
+                this.z.smoothstep(edge0.z, edge1.z))
 
 fun Vector4.smoothstep(edge0: Vector4, edge1: Vector4): Vector4 =
         Vector4(this.x.smoothstep(edge0.x, edge1.x),
-                this.x.smoothstep(edge0.y, edge1.y),
-                this.x.smoothstep(edge0.z, edge1.z),
-                this.x.smoothstep(edge0.w, edge1.w))
+                this.y.smoothstep(edge0.y, edge1.y),
+                this.z.smoothstep(edge0.z, edge1.z),
+                this.w.smoothstep(edge0.w, edge1.w))
 
 /**
  * Smoothstep

--- a/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMapping.kt
+++ b/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMapping.kt
@@ -131,6 +131,42 @@ class TestMapping {
     }
 
     @Test
+    fun shouldDoSmoothstepOperations() {
+        describe("Smoothstep Vector2") {
+            val edge0 = Vector2.ZERO
+            val edge1 = Vector2.ONE
+            val x = Vector2(0.0, 1.0)
+            val expectedResult = Vector2(0.0, 1.0)
+
+            it("should apply smoothstep component-wise") {
+                x.smoothstep(edge0, edge1).closeTo(expectedResult, 10E-6)
+            }
+        }
+
+        describe("Smoothstep Vector3") {
+            val edge0 = Vector3.ZERO
+            val edge1 = Vector3.ONE
+            val x = Vector3(0.0, 0.5, 1.0)
+            val expectedResult = Vector3(0.0, 0.5, 1.0)
+
+                it("should apply smoothstep component-wise") {
+                x.smoothstep(edge0, edge1).closeTo(expectedResult, 10E-6)
+            }
+        }
+
+        describe("Smoothstep Vector4") {
+            val edge0 = Vector4.ZERO
+            val edge1 = Vector4.ONE
+            val x = Vector4(0.0, 0.3, 0.6, 1.0)
+            val expectedResult = Vector4(0.0, 0.216, 0.648, 1.0)
+
+                it("should apply smoothstep component-wise") {
+                x.smoothstep(edge0, edge1).closeTo(expectedResult, 10E-6)
+            }
+        }
+    }
+
+    @Test
     fun shouldDoMixingOperations() {
         describe("Mixing double") {
             it("should produce expected result") {


### PR DESCRIPTION
I was wondering if this is actually the intended behavior or a bug. In the implementations of the extension function `smoothstep` for `Vector2`, `Vector3` and `Vector4`, the coordinate `this.x` is always used as input for the `Double.smoothstep` extension function, ignoring the other coordinates.

To me, it would make sense that the smoothstep function is applied component-wise. I suppose it's just a copy-paste error.

I also added tests to verify the new behavior. I'm sorry if I didn't use the currently recommended libraries, I preferred to use the ones that were already in use in the file that I modified (and if I get it right, the `openrndr-math` module doesn't have the new libraries in its dependencies yet).