### PR TITLE
[openrndr-math] Fix bug in matrix division by a scalar

### DIFF
--- a/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Matrix33.kt
+++ b/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Matrix33.kt
@@ -90,13 +90,13 @@ data class Matrix33(
             v.x * c0r1 + v.y * c1r1 + v.z * c2r1,
             v.x * c0r2 + v.y * c1r2 + v.z * c2r2)
 
-    override operator fun times(scale: Double) = Matrix33(scale * c0r0, scale * c1r0, scale * c2r0,
-            scale * c0r1, scale * c1r1, scale * c2r1,
-            scale * c0r2, scale * c1r2, scale * c2r2)
+    override operator fun times(scale: Double) = Matrix33(c0r0 * scale, c1r0 * scale, c2r0 * scale,
+            c0r1 * scale, c1r1 * scale, c2r1 * scale,
+            c0r2 * scale, c1r2 * scale, c2r2 * scale)
 
-    override operator fun div(scale: Double) = Matrix33(scale / c0r0, scale / c1r0, scale / c2r0,
-            scale / c0r1, scale / c1r1, scale / c2r1,
-            scale / c0r2, scale / c1r2, scale / c2r2)
+    override operator fun div(scale: Double) = Matrix33(c0r0 / scale, c1r0 / scale, c2r0 / scale,
+            c0r1 / scale, c1r1 / scale, c2r1 / scale,
+            c0r2 / scale, c1r2 / scale, c2r2 / scale)
 
     operator fun times(mat: Matrix33) = Matrix33(
             this.c0r0 * mat.c0r0 + this.c1r0 * mat.c0r1 + this.c2r0 * mat.c0r2,

--- a/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Matrix44.kt
+++ b/openrndr-math/src/commonMain/kotlin/org/openrndr/math/Matrix44.kt
@@ -182,15 +182,15 @@ data class Matrix44(
     /**
      * Multiplies all the elements in the 4x4 matrix with a scalar
      */
-    override operator fun times(scale: Double) = Matrix44(scale * c0r0, scale * c1r0, scale * c2r0, scale * c3r0,
-            scale * c0r1, scale * c1r1, scale * c2r1, scale * c3r1,
-            scale * c0r2, scale * c1r2, scale * c2r2, scale * c3r2,
-            scale * c0r3, scale * c1r3, scale * c2r3, scale * c3r3)
+    override operator fun times(scale: Double) = Matrix44(c0r0 * scale, c1r0 * scale, c2r0 * scale, c3r0 * scale,
+            c0r1 * scale, c1r1 * scale, c2r1 * scale, c3r1 * scale,
+            c0r2 * scale, c1r2 * scale, c2r2 * scale, c3r2 * scale,
+            c0r3 * scale, c1r3 * scale, c2r3 * scale, c3r3 * scale)
 
-    override operator fun div(scale: Double) = Matrix44(scale / c0r0, scale / c1r0, scale / c2r0, scale / c3r0,
-            scale / c0r1, scale / c1r1, scale / c2r1, scale / c3r1,
-            scale / c0r2, scale / c1r2, scale / c2r2, scale / c3r2,
-            scale / c0r3, scale / c1r3, scale / c2r3, scale / c3r3)
+    override operator fun div(scale: Double) = Matrix44(c0r0 / scale, c1r0 / scale, c2r0 / scale, c3r0 / scale,
+            c0r1 / scale, c1r1 / scale, c2r1 / scale, c3r1 / scale,
+            c0r2 / scale, c1r2 / scale, c2r2 / scale, c3r2 / scale,
+            c0r3 / scale, c1r3 / scale, c2r3 / scale, c3r3 / scale)
 
 
     /**

--- a/openrndr-math/src/commonTest/kotlin/org/openrndr/math/CloseToHelpers.kt
+++ b/openrndr-math/src/commonTest/kotlin/org/openrndr/math/CloseToHelpers.kt
@@ -25,6 +25,19 @@ fun Vector4.closeTo(expected: Vector4, delta: Double) = this.should("\n[$this]\n
             ((this.w - expected.w).absoluteValue - delta) <= 0.0
 }
 
+fun Matrix33.closeTo(expected: Matrix33, delta: Double) = this.should("\n[$this]\nand\n[$expected]\nshould be equal within an accuracy of $delta") {
+
+    ((this.c0r0 - expected.c0r0).absoluteValue - delta) <= 0.0 &&
+            ((this.c0r1 - expected.c0r1).absoluteValue - delta) <= 0.0 &&
+            ((this.c0r2 - expected.c0r2).absoluteValue - delta) <= 0.0 &&
+            ((this.c1r0 - expected.c1r0).absoluteValue - delta) <= 0.0 &&
+            ((this.c1r1 - expected.c1r1).absoluteValue - delta) <= 0.0 &&
+            ((this.c1r2 - expected.c1r2).absoluteValue - delta) <= 0.0 &&
+            ((this.c2r0 - expected.c2r0).absoluteValue - delta) <= 0.0 &&
+            ((this.c2r1 - expected.c2r1).absoluteValue - delta) <= 0.0 &&
+            ((this.c2r2 - expected.c2r2).absoluteValue - delta) <= 0.0
+}
+
 fun Matrix44.closeTo(expected: Matrix44, delta: Double) = this.should("\n[$this]\nand\n[$expected]\nshould be equal within an accuracy of $delta") {
 
     ((this.c0r0 - expected.c0r0).absoluteValue - delta) <= 0.0 &&

--- a/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMatrix33.kt
+++ b/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMatrix33.kt
@@ -50,6 +50,38 @@ class TestMatrix33 {
             val inversed = nd.inversed
             (nd * inversed).trace shouldBe (3.0 plusOrMinus maxError)
         }
+
+        it("multiplication by a scalar") {
+            val m = Matrix33(
+                1.0, 2.0, 3.0,
+                4.0, 5.0, 6.0,
+                7.0, 8.0, 9.0
+            )
+            val expectedResult = Matrix33(
+                2.0, 4.0, 6.0,
+                8.0, 10.0, 12.0,
+                14.0, 16.0, 18.0
+            )
+
+            val operationResult = m * 2.0
+            operationResult.closeTo(expectedResult, maxError)
+        }
+
+        it("division by a scalar") {
+            val m = Matrix33(
+                1.0, 2.0, 3.0,
+                4.0, 5.0, 6.0,
+                7.0, 8.0, 9.0
+            )
+            val expectedResult = Matrix33(
+                0.5, 1.0, 1.5,
+                2.0, 2.5, 3.0,
+                3.5, 4.0, 4.5
+            )
+
+            val operationResult = m / 2.0
+            operationResult.closeTo(expectedResult, maxError)
+        }
     }
 
 }

--- a/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMatrix44.kt
+++ b/openrndr-math/src/commonTest/kotlin/org/openrndr/math/TestMatrix44.kt
@@ -1,0 +1,50 @@
+package org.openrndr.math
+
+import org.openrndr.math.test.it
+import kotlin.test.Test
+
+class TestMatrix44 {
+
+    private val maxError = 0.0000001
+
+    @Test
+    fun doMatrix44Operations() {
+
+        it("multiplication by a scalar") {
+            val m = Matrix44(
+                1.0, 2.0, 3.0, 4.0,
+                5.0, 6.0, 7.0, 8.0,
+                9.0, 10.0, 11.0, 12.0,
+                13.0, 14.0, 15.0, 16.0
+            )
+            val expectedResult = Matrix44(
+                2.0, 4.0, 6.0, 8.0,
+                10.0, 12.0, 14.0, 16.0,
+                18.0, 20.0, 22.0, 24.0,
+                26.0, 28.0, 30.0, 32.0
+            )
+
+            val operationResult = m * 2.0
+            operationResult.closeTo(expectedResult, maxError)
+        }
+
+        it("division by a scalar") {
+            val m = Matrix44(
+                1.0, 2.0, 3.0, 4.0,
+                5.0, 6.0, 7.0, 8.0,
+                9.0, 10.0, 11.0, 12.0,
+                13.0, 14.0, 15.0, 16.0
+            )
+            val expectedResult = Matrix44(
+                0.5, 1.0, 1.5, 2.0,
+                2.5, 3.0, 3.5, 4.0,
+                4.5, 5.0, 5.5, 6.0,
+                6.5, 7.0, 7.5, 8.0
+            )
+
+            val operationResult = m / 2.0
+            operationResult.closeTo(expectedResult, maxError)
+        }
+    }
+
+}


### PR DESCRIPTION
The bug is that each position of the final matrix is computed as the scalar divided by the corresponding position of the original matrix, instead of the other way around.

The bug is present in the implementation of the `div` operator of the classes `Matrix33` and `Matrix44`.

I also swapped the values in the `times` operator implementation for consistency, even though the result is the same.

I added some tests to verify that my changes are correct.