### PR TITLE
Add toolchain resolver for automatic downloads

### DIFF
--- a/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-jvm.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 kotlin {
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmTarget.get()))
+        vendor.set(JvmVendorSpec.ADOPTIUM)
     }
 }
 

--- a/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/openrndr/convention/kotlin-multiplatform.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     jvm {
         jvmToolchain {
             languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmTarget.get()))
+            vendor.set(JvmVendorSpec.ADOPTIUM)
         }
         testRuns["test"].executionTask {
             useJUnitPlatform()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,9 @@
 rootProject.name = "openrndr"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+}
+
 include(
     listOf(
         "openrndr-application",


### PR DESCRIPTION
With this PR, if you don't have a matching toolchain on your system, Gradle will download one automatically to use it. I couldn't use the project catalog for the foojay-resolver-convention plugin as the project catalog isn't accessible in settings.gradle.kts.