### PR TITLE
Add MouseTracker

### DIFF
--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/Mouse.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/Mouse.kt
@@ -35,7 +35,9 @@ data class MouseEvent(val position: Vector2, val rotation: Vector2, val dragDisp
     }
 }
 
-
+/**
+ * Mouse cursor types
+ */
 enum class CursorType {
     ARROW_CURSOR,
     IBEAM_CURSOR,
@@ -47,7 +49,6 @@ enum class CursorType {
 
 interface MouseEvents {
 
-    val pressedButtons: MutableSet<MouseButton>
     val position: Vector2
 
     /**
@@ -187,6 +188,28 @@ class ApplicationMouse(private val application: () -> Application): MouseEvents 
      * Emitted from [Application] whenever the mouse exits the window client area
      */
     override val exited = Event<MouseEvent>("mouse-exited", postpone = true)
+}
 
-    override var pressedButtons = mutableSetOf<MouseButton>()
+/**
+ * Keeps track of which mouse buttons are currently pressed.
+ * Usage: `val mt = MouseTracker(mouse)`, then read `mt.pressedButtons`.
+ * Replaces `MouseEvents.pressedButtons`.
+ */
+class MouseTracker(mouseEvents: MouseEvents) {
+    private val mutablePressedButtons = mutableSetOf<MouseButton>()
+
+    /**
+     * set containing the names of the currently pressed buttons
+     */
+    val pressedButtons: Set<MouseButton> = mutablePressedButtons
+
+    init {
+        mouseEvents.buttonDown.listen {
+            mutablePressedButtons.add(it.button)
+        }
+
+        mouseEvents.buttonUp.listen {
+            mutablePressedButtons.remove(it.button)
+        }
+    }
 }

--- a/openrndr-demos/src/main/kotlin/DemoMouseTracker01.kt
+++ b/openrndr-demos/src/main/kotlin/DemoMouseTracker01.kt
@@ -1,0 +1,23 @@
+import org.openrndr.MouseButton
+import org.openrndr.MouseTracker
+import org.openrndr.application
+
+fun main() = application {
+    program {
+        val mouseTracker = MouseTracker(mouse)
+        extend {
+            if (MouseButton.LEFT in mouseTracker.pressedButtons) {
+                drawer.rectangle(drawer.bounds.sub(0.1, 0.1, 0.2, 0.9))
+            }
+
+            if (MouseButton.CENTER in mouseTracker.pressedButtons) {
+                drawer.rectangle(drawer.bounds.sub(0.45, 0.1, 0.55, 0.9))
+            }
+
+            if (MouseButton.RIGHT in mouseTracker.pressedButtons) {
+                drawer.rectangle(drawer.bounds.sub(0.8, 0.1, 0.9, 0.9))
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Adds MouseTracker (replacing pressedButtons), the same way KeyTracker replaced pressedKeys. 
I didn't use @deprecated because pressed keys also didn't use it.

This change makes https://github.com/openrndr/orx/pull/302 necessary, otherwise orx will not build.
