### PR TITLE
Reverse font face shape so winding is CLOCKWISE

### DIFF
--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/draw/font/FontDriverStbTt.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/draw/font/FontDriverStbTt.kt
@@ -123,7 +123,7 @@ class GlyphStbTt(private val face: FaceStbTt, private val character: Char, priva
             }
         }
         shape.free()
-        return Shape(shapeContours.map { it.close() })
+        return Shape(shapeContours.map { it.reversed.close() })
     }
 
     override fun advanceWidth(size: Double): Double {


### PR DESCRIPTION
This tries to fix the issue presented at https://openrndr.discourse.group/t/converting-font-characters-to-contours/576/2

I searched and it seems like the affected .shape() method is not called anywhere in openrndr or orx, so I don't expect side effects.

Without this change it seems like the outer contour is COUNTER_CLOCKWISE and the inner one is CLOCKWISE.