### PR TITLE
[openrndr-ffmpeg] Update to list actual device names on macOS

### DIFF
--- a/openrndr-jvm/openrndr-ffmpeg/src/main/kotlin/org/openrndr/ffmpeg/VideoPlayerFFMPEG.kt
+++ b/openrndr-jvm/openrndr-ffmpeg/src/main/kotlin/org/openrndr/ffmpeg/VideoPlayerFFMPEG.kt
@@ -313,7 +313,7 @@ class VideoPlayerFFMPEG private constructor(
                             val devicePattern = Regex("\\[AVFoundation .*] \\[[0-9]*] (?<name>.*)")
                             val matchResult = devicePattern.matchEntire(texts[lineIndex])
                             if (matchResult != null) {
-                                val (_, name) = matchResult.destructured
+                                val (name) = matchResult.destructured
                                 result.add(name)
                             }
                             lineIndex += 1


### PR DESCRIPTION
Just some formatting in the Windows section (better look at the diff ignoring whitespace changes).

On macOS there previously seemed to be a problem with the log formatting? Now, it seems possible to extract the device name with a simple regex pattern. Not sure if this could be a breaking change for some users?