### PR TITLE
[openrndr-draw] Deep copy a composition when nested inside another

### DIFF
--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/shape/CompositionDrawer.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/shape/CompositionDrawer.kt
@@ -664,7 +664,8 @@ class CompositionDrawer(documentBounds: CompositionDimensions = defaultCompositi
 
     fun composition(composition: Composition): CompositionNode {
         val rootContainer = GroupNode()
-        val newRoot = (composition.root as GroupNode).copy().also { it.parent = rootContainer }
+        val newRoot = composition.root.duplicate(insert = false)
+        newRoot.parent = rootContainer
         rootContainer.children.add(newRoot)
         rootContainer.transform *= model
         rootContainer.parent = cursor


### PR DESCRIPTION
Currently when a composition `c` is nested inside another, only the root `r` of `c` is copied. The result is not correct because all children of `r` have their `parent` reference set to their original root. The drawing function has no problem with this, which is probably why this wasn't noticed before. However, when manually doing things to the composition this might cause problems. For example, the `transform` property depends on the `parent` reference, so it is incorrect when the transform for the original composition differs from the transform for the new composition in which it is nested. My change makes a deep copy of `c` instead. 

Apparently I was the one that made this mistake 2 years ago, sorry for that 😅.