### PR TITLE
[openrndr-shape] Fix ShapeContour winding

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
@@ -110,10 +110,15 @@ data class ShapeContour @JvmOverloads constructor(
     val winding: Winding
         get() {
             var sum = 0.0
-            segments.forEachIndexed { i, v ->
-                val after = segments[mod(i + 1, segments.size)].start
-                sum += (after.x - v.start.x) * (after.y + v.start.y)
+            segments.forEach { s ->
+                (listOf(s.start) + s.control + listOf(s.end)).zipWithNext { a, b ->
+                    sum += (b.x - a.x) * (b.y + a.y)
+                }
             }
+            val start = segments.first().start
+            val end = segments.last().end
+            sum += (start.x - end.x) * (start.y + end.y)
+
             return when (polarity) {
                 YPolarity.CCW_POSITIVE_Y -> if (sum < 0) {
                     Winding.COUNTER_CLOCKWISE


### PR DESCRIPTION
This fixes two issues:
- For 2-segment closed contours the winding was always counter-clockwise, but this can be clockwise as well depending on the control points. This is fixed by taking control points into account.
- For open contours the last segment was ignored, which may result in an incorrect winding.