### PR TITLE
Ensure .sampleEquidistant() and .equidistantPositions()  returns the requested number of points

### DIFF
--- a/openrndr-core/src/test/kotlin/TestContourBuilder.kt
+++ b/openrndr-core/src/test/kotlin/TestContourBuilder.kt
@@ -193,7 +193,7 @@ class TestContourBuilder : DescribeSpec({
             c[1].segments.size `should be equal to` 1
         }
 
-        it("supports multiple open org.openrndr.shape.contours") {
+        it("supports multiple closed org.openrndr.shape.contours") {
             val c = contours {
                 moveTo(200.0, 200.0)
                 lineTo(300.0, 200.0)

--- a/openrndr-core/src/test/kotlin/TestLineSegment.kt
+++ b/openrndr-core/src/test/kotlin/TestLineSegment.kt
@@ -14,21 +14,21 @@ class TestLineSegment : DescribeSpec({
         }
     }
 
-    describe("a T shaped crossing horizontal and vertical line segment") {
+    describe("a ┬ shaped crossing of horizontal and vertical line segments") {
         val h = LineSegment(-100.0, 0.0, 100.0, 0.0)
         val v = LineSegment(0.0, 0.0, 0.0, 100.0)
 
-        it("they should intersect") {
+        it("should intersect") {
             val i = intersection(h, v, eps = 0.0)
             i `should be near` Vector2.ZERO
         }
     }
 
-    describe("a T shaped crossing horizontal and vertical line segment") {
+    describe("a ├ shaped crossing of horizontal and vertical line segments") {
         val h = LineSegment(0.0, 0.0, 100.0, 0.0)
         val v = LineSegment(0.0, -100.0, 0.0, 100.0)
 
-        it("they should intersect") {
+        it("should intersect") {
             val i = intersection(h, v, eps = 0.0)
             i `should be near` Vector2.ZERO
         }

--- a/openrndr-core/src/test/kotlin/TestRectangle.kt
+++ b/openrndr-core/src/test/kotlin/TestRectangle.kt
@@ -49,7 +49,7 @@ class TestRectangle : DescribeSpec({
 
         it("can be sampled for equidistant positions") {
             val eps = c.equidistantPositions(10)
-            eps.size `should be equal to` 11
+            eps.size `should be equal to` 10
 
             for (p in eps) {
                 p.x `should be greater or equal to` 100.0 - 1E-6

--- a/openrndr-core/src/test/kotlin/TestShapeContour.kt
+++ b/openrndr-core/src/test/kotlin/TestShapeContour.kt
@@ -105,6 +105,9 @@ class TestShapeContour : DescribeSpec({
             continueTo(Vector2(0.9 * width, 0.3 * height))
         }
 
+        it("returns the expected number of points for equidistantPositions") {
+            curve.equidistantPositions(100).size `should be equal to` 100
+        }
     }
 
     describe("a simple closed contour") {
@@ -141,6 +144,10 @@ class TestShapeContour : DescribeSpec({
                 resampled.position(0.0) `should be near` curve.position(0.0)
                 resampled.position(1.0) `should be near` curve.position(1.0)
             }
+        }
+
+        it("returns the expected number of points for equidistantPositions") {
+            curve.equidistantPositions(100).size `should be equal to` 100
         }
     }
 
@@ -212,14 +219,14 @@ class TestShapeContour : DescribeSpec({
             curve.sub(-1.0, -1.0)
 
         }
-        it("it can be subbed from 0.0 to 0.001 ") {
+//        it("it can be subbed from 0.0 to 0.001 ") {
 //            for (i in -2000 .. 10000) {
 //                val o = i / 10000
 //                val s = curve.sub(0.0 + o, 0.01 + o)
 //                s.position(0.0) `should be somewhat near` curve.position(0.0 + o)
 //                s.position(1.0) `should be somewhat near` curve.position(0.01+ o)
 //            }
-        }
+//        }
 
         it("it can be subbed from 0.0 to 0.001 ") {
             val s = curve.sub(0.0, 1 / 100000.0)

--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt
@@ -399,7 +399,7 @@ data class ShapeContour @JvmOverloads constructor(
             sampleEquidistant(
                 adaptivePositions(distanceTolerance),
                 pointCount + if (closed) 1 else 0
-            )
+            ).take(pointCount)
         }
 
     fun equidistantPositionsWithT(pointCount: Int, distanceTolerance: Double = 0.5) =
@@ -409,7 +409,7 @@ data class ShapeContour @JvmOverloads constructor(
             sampleEquidistantWithT(
                 adaptivePositionsWithT(distanceTolerance),
                 pointCount + if (closed) 1 else 0
-            )
+            ).take(pointCount)
         }
 
     /**
@@ -427,19 +427,12 @@ data class ShapeContour @JvmOverloads constructor(
         }
 
     /** Samples the [ShapeContour] into equidistant linear [Segment]s. */
-    fun sampleEquidistant(pointCount: Int): ShapeContour {
+    fun sampleEquidistant(pointCount: Int) =
         if (empty) {
-            return EMPTY
+            EMPTY
+        } else {
+            fromPoints(equidistantPositions(pointCount.coerceAtLeast(2)), closed, polarity)
         }
-        val points = equidistantPositions(pointCount.coerceAtLeast(2))
-        val segments = (0 until points.size - 1).map {
-            Segment(
-                points[it],
-                points[it + 1]
-            )
-        }
-        return ShapeContour(segments, closed, polarity)
-    }
 
     /** Applies linear transformation to [ShapeContour]. */
     fun transform(transform: Matrix44) =


### PR DESCRIPTION
Otherwise it is a bit odd that the user asks for a number of points but receives one more than requested. Also, this causes problems in orx-triangulation with the extra point, unless remembering to call `.take(N)`.