### PR TITLE
Add Path3D.position test, fix method

### DIFF
--- a/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Path3D.kt
+++ b/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/Path3D.kt
@@ -34,10 +34,15 @@ class Path3D(val segments: List<Segment3D>, val closed: Boolean) {
 
 
     fun position(ut: Double): Vector3 {
-        val t = ut.coerceIn(0.0, 1.0)
-        val segment = (t * segments.size).toInt()
-        val segmentOffset = (t * segments.size) - segment
-        return segments[min(segments.size - 1, segment)].position(segmentOffset)
+        return when(val t = ut.coerceIn(0.0, 1.0)) {
+            0.0 -> segments[0].start
+            1.0 -> segments.last().end
+            else -> {
+                val segment = (t * segments.size).toInt()
+                val segmentOffset = (t * segments.size) - segment
+                segments[min(segments.size - 1, segment)].position(segmentOffset)
+            }
+        }
     }
 
     fun adaptivePositions(distanceTolerance: Double = 0.5): List<Vector3> {

--- a/openrndr-shape/src/commonTest/kotlin/Path3DTest.kt
+++ b/openrndr-shape/src/commonTest/kotlin/Path3DTest.kt
@@ -1,0 +1,40 @@
+import org.openrndr.math.Vector3
+import org.openrndr.shape.Path3D
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Path3DTest {
+    private fun assertEquals(expected: Vector3, actual: Vector3, absoluteTolerance: Double, message: String? = null) {
+        assertEquals(expected.x, actual.x, absoluteTolerance, "$message (x differs)")
+        assertEquals(expected.y, actual.y, absoluteTolerance, "$message (y differs)")
+        assertEquals(expected.z, actual.z, absoluteTolerance, "$message (z differs)")
+    }
+
+    @Test
+    fun shouldCalculatePosition() {
+        val tolerance = 0.0005
+
+        val start = Vector3.UNIT_X * -5.0
+        val mid = Vector3.UNIT_Y
+        val end = Vector3.UNIT_X * 5.0
+
+        val path3D = Path3D.fromPoints(listOf(start, mid, end), false)
+
+        assertEquals(
+            start, path3D.position(0.0), tolerance,
+            "path3D.position(0.0) should return path start"
+        )
+        assertEquals(
+            mid, path3D.position(0.5), tolerance,
+            "path3D.position(0.5) should return path mid point"
+        )
+        assertEquals(
+            end, path3D.position(1.0), tolerance,
+            "path3D.position(1.0) should return path end"
+        )
+        assertEquals(
+            start.mix(mid, 0.2), path3D.position(0.1), tolerance,
+            "path3D.position(0.1) should equal point at t=0.2 between start and mid"
+        )
+    }
+}


### PR DESCRIPTION
.position(1.0) was not returning the end position

Change inspired by https://github.com/openrndr/openrndr/blob/master/openrndr-shape/src/commonMain/kotlin/org/openrndr/shape/ShapeContour.kt#L254