### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/release-apidocs.yml
+++ b/.github/workflows/release-apidocs.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/release-candidate-to-maven-central.yml
+++ b/.github/workflows/release-candidate-to-maven-central.yml
@@ -8,8 +8,8 @@ jobs:
   release_candidate_to_maven_central:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -9,8 +9,8 @@ jobs:
   release_to_maven_central:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1.0.6
+        uses: gradle/actions/wrapper-validation@v3
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
@@ -43,6 +43,7 @@ jobs:
           swap-size-gb: 8
 
       - name: Test openrndr-gl3
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: coactions/setup-xvfb@v1
         with:
           run: ./gradlew :openrndr-jvm:openrndr-gl3:jvmHeavyTest
+


### PR DESCRIPTION
```
generate_screenshots
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, gradle/wrapper-validation-action@v1.0.5, actions/setup-java@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Note that `GabrielBB/xvfb-action` is deprecated and I replaced it by `coactions/setup-xvfb`