### PR TITLE
Add GL_VERTEX_PROGRAM_POINT_SIZE support

### DIFF
--- a/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingPoint.kt
+++ b/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingPoint.kt
@@ -3,27 +3,25 @@ import org.openrndr.draw.shadeStyle
 import org.openrndr.math.Vector2
 import kotlin.math.sin
 
-fun main() {
-    application {
-        program {
-            val style = shadeStyle {
-                vertexTransform = """
-                    x_pointSize = p_pointSize;
-                """.trimIndent()
-                fragmentTransform = """
-                    // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
-                    vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
-                    float distance = length(pointPosition);
-                    float luma = smoothstep(1.0, .7, distance);
-                    luma *= va_pointSize / 100.0;
-                    x_fill.rgb = vec3(luma);
-                """.trimIndent()
-            }
-            extend {
-                style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
-                drawer.shadeStyle = style
-                drawer.point(Vector2(width / 2.0, height / 2.0))
-            }
+fun main() = application {
+    program {
+        val style = shadeStyle {
+            vertexTransform = """
+                x_pointSize = p_pointSize;
+            """.trimIndent()
+            fragmentTransform = """
+                // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
+                vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
+                float distance = length(pointPosition);
+                float luma = smoothstep(1.0, .7, distance);
+                luma *= va_pointSize / 100.0;
+                x_fill.rgb = vec3(luma);
+            """.trimIndent()
+        }
+        extend {
+            style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
+            drawer.shadeStyle = style
+            drawer.point(Vector2(width / 2.0, height / 2.0))
         }
     }
 }

--- a/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingPoint.kt
+++ b/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingPoint.kt
@@ -1,0 +1,29 @@
+import org.openrndr.application
+import org.openrndr.draw.shadeStyle
+import org.openrndr.math.Vector2
+import kotlin.math.sin
+
+fun main() {
+    application {
+        program {
+            val style = shadeStyle {
+                vertexTransform = """
+                    x_pointSize = p_pointSize;
+                """.trimIndent()
+                fragmentTransform = """
+                    // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
+                    vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
+                    float distance = length(pointPosition);
+                    float luma = smoothstep(1.0, .7, distance);
+                    luma *= va_pointSize / 100.0;
+                    x_fill.rgb = vec3(luma);
+                """.trimIndent()
+            }
+            extend {
+                style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
+                drawer.shadeStyle = style
+                drawer.point(Vector2(width / 2.0, height / 2.0))
+            }
+        }
+    }
+}

--- a/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingVertexBuffer.kt
+++ b/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingVertexBuffer.kt
@@ -1,0 +1,41 @@
+import org.openrndr.application
+import org.openrndr.draw.DrawPrimitive
+import org.openrndr.draw.shadeStyle
+import org.openrndr.draw.vertexBuffer
+import org.openrndr.draw.vertexFormat
+import org.openrndr.math.Vector3
+import kotlin.math.sin
+
+fun main() {
+    application {
+        program {
+            val points = vertexBuffer(
+                vertexFormat {
+                    position(3)
+                },
+                vertexCount = 1
+            )
+            points.put {
+                write(Vector3(width / 2.0, height / 2.0, 0.0))
+            }
+            val style = shadeStyle {
+                vertexTransform = """
+                    x_pointSize = p_pointSize;
+                """.trimIndent()
+                fragmentTransform = """
+                    // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
+                    vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
+                    float distance = length(pointPosition);
+                    float luma = smoothstep(1.0, .7, distance);
+                    luma *= va_pointSize / 100.0;
+                    x_fill.rgb = vec3(luma);
+                """.trimIndent()
+            }
+            extend {
+                style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
+                drawer.shadeStyle = style
+                drawer.vertexBuffer(points, DrawPrimitive.POINTS)
+            }
+        }
+    }
+}

--- a/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingVertexBuffer.kt
+++ b/openrndr-demos/src/main/kotlin/DemoPointSizeWhenDrawingVertexBuffer.kt
@@ -6,36 +6,34 @@ import org.openrndr.draw.vertexFormat
 import org.openrndr.math.Vector3
 import kotlin.math.sin
 
-fun main() {
-    application {
-        program {
-            val points = vertexBuffer(
-                vertexFormat {
-                    position(3)
-                },
-                vertexCount = 1
-            )
-            points.put {
-                write(Vector3(width / 2.0, height / 2.0, 0.0))
-            }
-            val style = shadeStyle {
-                vertexTransform = """
-                    x_pointSize = p_pointSize;
-                """.trimIndent()
-                fragmentTransform = """
-                    // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
-                    vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
-                    float distance = length(pointPosition);
-                    float luma = smoothstep(1.0, .7, distance);
-                    luma *= va_pointSize / 100.0;
-                    x_fill.rgb = vec3(luma);
-                """.trimIndent()
-            }
-            extend {
-                style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
-                drawer.shadeStyle = style
-                drawer.vertexBuffer(points, DrawPrimitive.POINTS)
-            }
+fun main() = application {
+    program {
+        val points = vertexBuffer(
+            vertexFormat {
+                position(3)
+            },
+            vertexCount = 1
+        )
+        points.put {
+            write(Vector3(width / 2.0, height / 2.0, 0.0))
+        }
+        val style = shadeStyle {
+            vertexTransform = """
+                x_pointSize = p_pointSize;
+            """.trimIndent()
+            fragmentTransform = """
+                // TODO in the future it should be rather c_boundsPosition instead of gl_PointCoord
+                vec2 pointPosition = (gl_PointCoord - .5) * 2.0;
+                float distance = length(pointPosition);
+                float luma = smoothstep(1.0, .7, distance);
+                luma *= va_pointSize / 100.0;
+                x_fill.rgb = vec3(luma);
+            """.trimIndent()
+        }
+        extend {
+            style.parameter("pointSize", (sin(seconds) * .5 + .5) * 99.0 + 1.0)
+            drawer.shadeStyle = style
+            drawer.vertexBuffer(points, DrawPrimitive.POINTS)
         }
     }
 }

--- a/openrndr-gl-common/src/commonMain/kotlin/ShaderGeneratorsGLCommon.kt
+++ b/openrndr-gl-common/src/commonMain/kotlin/ShaderGeneratorsGLCommon.kt
@@ -44,6 +44,7 @@ class ShaderGeneratorsGLCommon : ShaderGenerators {
 |${if (!shadeStructure.suppressDefaultOutput) "out vec4 o_color;" else ""}
 
 |flat in int v_instance;
+|flat in float va_pointSize;
 |${fragmentMainConstants(element = "v_instance")}
 |${shadeStructure.fragmentPreamble ?: ""}
 |void main(void) {
@@ -72,6 +73,7 @@ ${transformVaryingOut}
 ${shadeStructure.vertexPreamble ?: ""}
 
 flat out int v_instance;
+flat out float va_pointSize;
 void main() {
     int instance = gl_InstanceID; // this will go use c_instance instead
 ${vertexMainConstants()}
@@ -79,6 +81,7 @@ ${shadeStructure.varyingBridge ?: ""}
     vec3 x_normal = vec3(0.0, 0.0, 0.0);
     ${if (shadeStructure.attributes?.contains("vec3 a_normal;") == true) "x_normal = a_normal;" else ""}
     vec3 x_position = a_position;
+    float x_pointSize = 1.0;
 
     ${preVertexTransform}
     {
@@ -88,6 +91,8 @@ ${shadeStructure.vertexTransform?.prependIndent("        ") ?: ""}
 
     v_instance = instance;
     gl_Position = v_clipPosition;
+    gl_PointSize = x_pointSize;
+    va_pointSize = x_pointSize;
 }
             """.trimMargin()
 
@@ -271,6 +276,7 @@ ${if (!shadeStructure.suppressDefaultOutput) "out vec4 o_color;" else ""}
 
 flat in int v_instance;
 in vec3 v_boundsSize;
+flat in float va_pointSize;
 ${
         fragmentMainConstants(boundsPosition = "vec3(0.0, 0.0, 0.0)", boundsSize = "v_boundsSize")
     }
@@ -304,6 +310,7 @@ ${shadeStructure.vertexPreamble ?: ""}
 
 flat out int v_instance;
 out vec3 v_boundsSize;
+flat out float va_pointSize;
 void main() {
     v_instance = gl_InstanceID;
 
@@ -313,12 +320,15 @@ void main() {
     ${preVertexTransform}
     vec3 x_normal = vec3(0.0, 0.0, 1.0);
     vec3 x_position = a_position  + i_offset;
+    float x_pointSize = 1.0;
     {
 ${shadeStructure.vertexTransform?.prependIndent("        ") ?: ""}
     }
     va_position = x_position;
     ${postVertexTransform}
     gl_Position = v_clipPosition;
+    gl_PointSize = x_pointSize;
+    va_pointSize = x_pointSize;
 }"""
 
 

--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
@@ -1192,6 +1192,9 @@ class DriverGL3(val version: DriverVersionGL) : Driver {
             }
             cached.cullTestPass = drawStyle.cullTestPass
         }
+
+        glEnable(GL_VERTEX_PROGRAM_POINT_SIZE)
+
         dirtyPerContext[contextID] = false
         debugGLErrors()
 


### PR DESCRIPTION
I added `va_pointSize` to be carried from vertext shader to fragment shader. I'm not sure if it's the right convention.

The only way to use point coordinates at the moment is directly by `gl_PointCoord`. Probably it should be changed to some convention, like `c_boundsPosition`, however I am not sure if would conflict with other uses of `drawer.point`,  `drawer.points`, `drawer.vertexBuffer`. It seems that it can be added easily in the future as a down-compatible change, once it is clarified what's the best approach.