### PR TITLE
Add createByteBuffer() method to ShaderStorageBufferGL43

### DIFF
--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/ShaderStorageBuffer.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/ShaderStorageBuffer.kt
@@ -6,7 +6,7 @@ actual interface ShaderStorageBuffer {
 
     fun write(source: ByteBuffer, writeOffset: Int = 0)
     fun read(target: ByteBuffer, readOffset: Int = 0)
-    fun makeByteBuffer(): ByteBuffer
+    fun createByteBuffer(): ByteBuffer
     actual val session: Session?
     actual val format: ShaderStorageFormat
     actual fun clear()

--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/ShaderStorageBuffer.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/ShaderStorageBuffer.kt
@@ -6,6 +6,7 @@ actual interface ShaderStorageBuffer {
 
     fun write(source: ByteBuffer, writeOffset: Int = 0)
     fun read(target: ByteBuffer, readOffset: Int = 0)
+    fun makeByteBuffer(): ByteBuffer
     actual val session: Session?
     actual val format: ShaderStorageFormat
     actual fun clear()

--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ShaderStorageBufferGL43.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ShaderStorageBufferGL43.kt
@@ -100,14 +100,14 @@ class ShaderStorageBufferGL43(
     }
 
     /**
-     * Make a byte buffer matching the format size
+     * Create a byte buffer matching the format size
      * to be able to download the SSBO to the CPU.
      * Note that the buffer will contain padding
      * following elements that need it.
      *
      * @return a [ByteBuffer] with the expected size.
      */
-    override fun makeByteBuffer(): ByteBuffer =
+    override fun createByteBuffer(): ByteBuffer =
         ByteBuffer.allocateDirect(format.size).order(ByteOrder.nativeOrder())
 
     override fun destroy() {

--- a/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ShaderStorageBufferGL43.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmMain/kotlin/org/openrndr/internal/gl3/ShaderStorageBufferGL43.kt
@@ -8,6 +8,7 @@ import org.lwjgl.opengles.GLES30
 import org.openrndr.draw.*
 import org.openrndr.internal.Driver
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 class ShaderStorageBufferGL43(
     val buffer: Int,
@@ -98,6 +99,17 @@ class ShaderStorageBufferGL43(
         }
     }
 
+    /**
+     * Make a byte buffer matching the format size
+     * to be able to download the SSBO to the CPU.
+     * Note that the buffer will contain padding
+     * following elements that need it.
+     *
+     * @return a [ByteBuffer] with the expected size.
+     */
+    override fun makeByteBuffer(): ByteBuffer =
+        ByteBuffer.allocateDirect(format.size).order(ByteOrder.nativeOrder())
+
     override fun destroy() {
         if (!destroyed) {
             glDeleteBuffers(buffer)
@@ -111,7 +123,7 @@ class ShaderStorageBufferGL43(
         w.positionElements = elementOffset
         w.putter()
         if (w.position % format.size != 0) {
-            throw RuntimeException("incomplete members written. likely violating the specified shaders storage format $format")
+            throw RuntimeException("incomplete members written (position: ${w.position}, size: ${format.size}). likely violating the specified shaders storage format $format")
         }
         val count = w.positionElements
         shadow.uploadElements(elementOffset, count)


### PR DESCRIPTION
Simplifies downloading SSBO's to the CPU.