### PR TITLE
Add published version catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.nmcp)
     id("org.openrndr.convention.dokka")
     id 'com.adarshr.test-logger' version '4.0.0'
+    id 'version-catalog'
+    id 'maven-publish'
 }
 
 repositories {
@@ -27,6 +29,24 @@ subprojects {
         group = HelpTasksPlugin.HELP_GROUP
         description = "Displays all dependencies, including subprojects."
     }
+}
+
+catalog {
+    // declare the aliases, bundles and versions in this block
+    versionCatalog {
+        version('openrndr', "${version}")
+        library('animatable', 'org.openrndr', 'openrndr-animatable').versionRef('openrndr')
+        library('application', 'org.openrndr', 'openrndr-application').versionRef('openrndr')
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.versionCatalog
+        }
+    }
+
 }
 
 dependencies {
@@ -54,17 +74,6 @@ dependencies {
     dokka(project(":openrndr-js:openrndr-webgl:"))
 }
 
-tasks.every {
-    println(it)
-}
-
-class SleepTask extends DefaultTask {
-    @TaskAction
-    void action() {
-        sleep(60 * 5 * 1000)
-    }
-}
-tasks.register("sleep", SleepTask)
 gradle.buildFinished {
     println("\n")
     println("openrndr = \"${version}\"")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,8 @@ jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version
 jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
 kotest-assertions = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 kotest-runner = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest" }
+kotest-framework-engine = { group = "io.kotest", name = "kotest-framework-engine", version.ref = "kotest" }
+
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 
 [plugins]

--- a/openrndr-dependency-catalog/build.gradle.kts
+++ b/openrndr-dependency-catalog/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 catalog {
-    // declare the aliases, bundles and versions in this block
     versionCatalog {
         from(files("$rootDir/gradle/libs.versions.toml"))
     }

--- a/openrndr-dependency-catalog/build.gradle.kts
+++ b/openrndr-dependency-catalog/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `version-catalog`
+    `maven-publish`
+    signing
+}
+
+catalog {
+    // declare the aliases, bundles and versions in this block
+    versionCatalog {
+        from(files("$rootDir/gradle/libs.versions.toml"))
+    }
+}
+
+group = "org.openrndr"
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["versionCatalog"])
+        }
+    }
+}
+
+signing {
+    val isReleaseVersion = !(version.toString()).endsWith("SNAPSHOT")
+    setRequired({ isReleaseVersion && gradle.taskGraph.hasTask("publish") })
+    sign(publishing.publications)
+}

--- a/openrndr-module-catalog/build.gradle.kts
+++ b/openrndr-module-catalog/build.gradle.kts
@@ -13,7 +13,8 @@ catalog {
         library("dialogs", "org.openrndr:openrndr-dialogs:$version")
         library("draw", "org.openrndr:openrndr-draw:$version")
         library("event", "org.openrndr:openrndr-event:$version")
-        library("orextensions", "org.openrndr:openrndr-extensions:$version")
+        // we can't name this 'extensions' because it is a keyword in Gradle
+        library("extensions_", "org.openrndr:openrndr-extensions:$version")
         library("ffmpeg", "org.openrndr:openrndr-ffmpeg:$version")
         library("filter", "org.openrndr:openrndr-filter:$version")
         library("gl3", "org.openrndr:openrndr-gl3:$version")

--- a/openrndr-module-catalog/build.gradle.kts
+++ b/openrndr-module-catalog/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    `version-catalog`
+    `maven-publish`
+    signing
+}
+
+catalog {
+    versionCatalog {
+        library("animatable", "org.openrndr:openrndr-animatable:$version")
+        library("application", "org.openrndr:openrndr-application:$version")
+        library("binpack", "org.openrndr:openrndr-binpack:$version")
+        library("color", "org.openrndr:openrndr-color:$version")
+        library("dialogs", "org.openrndr:openrndr-dialogs:$version")
+        library("draw", "org.openrndr:openrndr-draw:$version")
+        library("event", "org.openrndr:openrndr-event:$version")
+        library("orextensions", "org.openrndr:openrndr-extensions:$version")
+        library("ffmpeg", "org.openrndr:openrndr-ffmpeg:$version")
+        library("filter", "org.openrndr:openrndr-filter:$version")
+        library("gl3", "org.openrndr:openrndr-gl3:$version")
+        library("gl-common", "org.openrndr:openrndr-gl-common:$version")
+        library("kartifex", "org.openrndr:openrndr-kartifex:$version")
+        library("ktessellation", "org.openrndr:openrndr-ktessellation:$version")
+        library("math", "org.openrndr:openrndr-math:$version")
+        library("openal", "org.openrndr:openrndr-openal:$version")
+        library("shape", "org.openrndr:openrndr-shape:$version")
+        library("utils", "org.openrndr:openrndr-utils:$version")
+    }
+}
+
+group = "org.openrndr"
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["versionCatalog"])
+        }
+    }
+}
+
+signing {
+    val isReleaseVersion = !(version.toString()).endsWith("SNAPSHOT")
+    setRequired({ isReleaseVersion && gradle.taskGraph.hasTask("publish") })
+    sign(publishing.publications)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,9 @@ include(
         "openrndr-utils",
         "openrndr-dds",
         "openrndr-kartifex",
-        "openrndr-ktessellation"
+        "openrndr-ktessellation",
+
+        "openrndr-dependency-catalog",
+        "openrndr-module-catalog"
     )
 )


### PR DESCRIPTION
Add the openrndr-dependency-catalog and openrndr-module-catalog modules. Both these modules publish a version catalog. The openrndr-dependency-catalog publishes the catalog found in libs.versions.toml while openrndr-module-catalog publishes a catalog of openrndr modules.