### PR TITLE
[openrndr-draw] Fix default font loading in Windows

### DIFF
--- a/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/FontMap.kt
+++ b/openrndr-draw/src/jvmMain/kotlin/org/openrndr/draw/FontMap.kt
@@ -69,7 +69,7 @@ actual val defaultFontMap by lazy {
     val defaultFontPath = File("data/fonts/default.otf")
     if (defaultFontPath.isFile) {
         logger.info { "loading default font from ${defaultFontPath.absolutePath}" }
-        loadFontImageMap(defaultFontPath.path, 16.0, contentScale = RenderTarget.active.contentScale)
+        loadFontImageMap(defaultFontPath.toURI().toString(), 16.0, contentScale = RenderTarget.active.contentScale)
     } else {
         logger.warn { "default font ${defaultFontPath.absolutePath} not found" }
         null


### PR DESCRIPTION
Default font loading worked in Linux but failed in Windows due to the use of
forward and back slashes. Using `toURI()` solves the problem.