### PR TITLE
ApplicationSDL: add dropTexts event

### DIFF
--- a/openrndr-application/src/commonJvmMain/kotlin/org/openrndr/WindowProgram.kt
+++ b/openrndr-application/src/commonJvmMain/kotlin/org/openrndr/WindowProgram.kt
@@ -259,7 +259,7 @@ open class WindowProgram(val suspend: Boolean = false) : Program {
         override val drop = Event<DropEvent>("window-drop", postpone = true)
 
         /**
-         * Drop event, triggered when files are dropped on the window
+         * Drop event, triggered when texts are dropped on the window
          */
         override val dropTexts = Event<DropTextEvent>("window-drop-text", postpone = true)
 

--- a/openrndr-application/src/commonJvmMain/kotlin/org/openrndr/WindowProgram.kt
+++ b/openrndr-application/src/commonJvmMain/kotlin/org/openrndr/WindowProgram.kt
@@ -254,9 +254,14 @@ open class WindowProgram(val suspend: Boolean = false) : Program {
         override val closed = Event<WindowEvent>("window-closed", postpone = true)
 
         /**
-         * Drop event, triggered when a file is dropped on the window
+         * Drop event, triggered when files are dropped on the window
          */
         override val drop = Event<DropEvent>("window-drop", postpone = true)
+
+        /**
+         * Drop event, triggered when files are dropped on the window
+         */
+        override val dropTexts = Event<DropTextEvent>("window-drop-text", postpone = true)
 
         /**
          * Window position

--- a/openrndr-application/src/commonMain/kotlin/org/openrndr/Program.kt
+++ b/openrndr-application/src/commonMain/kotlin/org/openrndr/Program.kt
@@ -34,10 +34,16 @@ enum class WindowEventType {
 data class WindowEvent(val type: WindowEventType, val position: Vector2, val size: Vector2, val focused: Boolean)
 
 /**
- * window drop item event message
+ * window drop file event message
  */
 @JvmRecord
 data class DropEvent(val position: Vector2, val files: List<String>)
+
+/**
+ * window drop text event message
+ */
+@JvmRecord
+data class DropTextEvent(val position: Vector2, val texts: List<String>)
 
 /**
  * program event type
@@ -253,14 +259,19 @@ interface Window {
     val restored: Event<WindowEvent>
 
     /**
-     * Window restored (from minimization) event
+     * Window closed event
      */
     val closed: Event<WindowEvent>
 
     /**
-     * Drop event, triggered when a file is dropped on the window
+     * Drop event, triggered when files are dropped on the window
      */
     val drop: Event<DropEvent>
+
+    /**
+     * Drop event, triggered when texts are dropped on the window
+     */
+    val dropTexts: Event<DropTextEvent>
 
     /**
      * Window position
@@ -480,6 +491,8 @@ open class ProgramImplementation(val suspend: Boolean = false) : Program {
         override val closed = Event<WindowEvent>("window-closed", postpone = true)
 
         override val drop = Event<DropEvent>("window-drop", postpone = true)
+
+        override val dropTexts = Event<DropTextEvent>("window-drop-text", postpone = true)
 
         override var position: Vector2
             get() = application.windowPosition

--- a/openrndr-jvm/openrndr-application-glfw/src/main/kotlin/ApplicationGLFWGL3.kt
+++ b/openrndr-jvm/openrndr-application-glfw/src/main/kotlin/ApplicationGLFWGL3.kt
@@ -1042,6 +1042,7 @@ class ApplicationGLFWGL3(override var program: Program, override var configurati
 
     private fun deliverEvents() {
         program.window.drop.deliver()
+        //program.window.dropTexts.deliver()
         program.window.sized.deliver()
         program.window.unfocused.deliver()
         program.window.focused.deliver()

--- a/openrndr-jvm/openrndr-application-glfw/src/main/kotlin/ApplicationWindowGLFW.kt
+++ b/openrndr-jvm/openrndr-application-glfw/src/main/kotlin/ApplicationWindowGLFW.kt
@@ -509,6 +509,7 @@ class ApplicationWindowGLFW(
          */
         glfwMakeContextCurrent(window)
         program.window.drop.deliver()
+        //program.window.dropTexts.deliver()
         program.window.sized.deliver()
         program.window.unfocused.deliver()
         program.window.focused.deliver()

--- a/openrndr-jvm/openrndr-application-sdl/src/demo/kotlin/DemoApplicationSdl01.kt
+++ b/openrndr-jvm/openrndr-application-sdl/src/demo/kotlin/DemoApplicationSdl01.kt
@@ -5,7 +5,13 @@ fun main() {
 
         program {
             window.drop.listen {
+                println("files")
                 println(it.files)
+            }
+
+            window.dropTexts.listen {
+                println("texts")
+                println(it.texts)
             }
 
             extend {

--- a/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
+++ b/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
@@ -82,6 +82,8 @@ class ApplicationSDL(override var program: Program, override var configuration: 
     private val windowsById = mutableMapOf<Int, ApplicationWindowSDL>()
 
     private val dropFiles = mutableListOf<String>()
+    private val dropTexts = mutableListOf<String>()
+    private var dropType = 0
 
 
     init {
@@ -430,6 +432,8 @@ class ApplicationSDL(override var program: Program, override var configuration: 
 
             SDL_EVENT_DROP_BEGIN -> {
                 dropFiles.clear()
+                dropTexts.clear()
+                dropType = 0
             }
 
             SDL_EVENT_DROP_FILE -> {
@@ -438,6 +442,16 @@ class ApplicationSDL(override var program: Program, override var configuration: 
                 if (data != null) {
                     dropFiles.add(data)
                 }
+                dropType = dropEvent.type()
+            }
+
+            SDL_EVENT_DROP_TEXT -> {
+                val dropEvent = event.drop()
+                val data = dropEvent.dataString()
+                if (data != null) {
+                    dropTexts.add(data)
+                }
+                dropType = dropEvent.type()
             }
 
             SDL_EVENT_DROP_COMPLETE -> {
@@ -446,12 +460,26 @@ class ApplicationSDL(override var program: Program, override var configuration: 
                     ?: run { logger.warn { "got event (=SDL_EVENT_DROP_COMPLETE) for unknown window id (=${windowId}): " }; return };
 
                 val dropEvent = event.drop()
-                eventWindow.program.window.drop.trigger(
-                    DropEvent(
-                        Vector2(dropEvent.x().toDouble(), dropEvent.y().toDouble()),
-                        dropFiles
-                    )
-                )
+
+                when (dropType) {
+                    SDL_EVENT_DROP_FILE -> {
+                        eventWindow.program.window.drop.trigger(
+                            DropEvent(
+                                Vector2(dropEvent.x().toDouble(), dropEvent.y().toDouble()),
+                                dropFiles
+                            )
+                        )
+                    }
+
+                    SDL_EVENT_DROP_TEXT -> {
+                        eventWindow.program.window.dropTexts.trigger(
+                            DropTextEvent(
+                                Vector2(dropEvent.x().toDouble(), dropEvent.y().toDouble()),
+                                dropTexts
+                            )
+                        )
+                    }
+                }
             }
 
             SDL_EVENT_MOUSE_WHEEL -> {
@@ -619,7 +647,7 @@ class ApplicationSDL(override var program: Program, override var configuration: 
      * Maps an SDL mouse button constant to a `MouseButton` constant
      * Note: SDL provides SDL_BUTTON_X1 and SDL_BUTTON_X2, but MouseButton doesn't.
      */
-    private fun getMouseButton(button: Int) = when(button) {
+    private fun getMouseButton(button: Int) = when (button) {
         SDL_BUTTON_LEFT -> MouseButton.LEFT
         SDL_BUTTON_MIDDLE -> MouseButton.CENTER
         SDL_BUTTON_RIGHT -> MouseButton.RIGHT

--- a/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
+++ b/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
@@ -479,6 +479,8 @@ class ApplicationSDL(override var program: Program, override var configuration: 
                             )
                         )
                     }
+
+                    else -> run { logger.warn { "got event (=SDL_EVENT_DROP_COMPLETE) with unsupported dropType (=$dropType): " }; return }
                 }
             }
 

--- a/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationWindowSDL.kt
+++ b/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationWindowSDL.kt
@@ -225,6 +225,7 @@ class ApplicationWindowSDL(
 
     fun deliverEvents() {
         program.window.drop.deliver()
+        program.window.dropTexts.deliver()
         program.window.sized.deliver()
         program.window.unfocused.deliver()
         program.window.focused.deliver()


### PR DESCRIPTION
Note: in Linux x11 with SDL, file drops are received as text drops. When switching from GLFW to SDL one needs to `window.dropTexts.listen {}` instead of `window.drop.listen {}` to detect file drops.