### PR TITLE
Add default blendMode to RenderTargetWebGL

### DIFF
--- a/openrndr-js/openrndr-webgl/src/webMain/kotlin/RenderTargetWebGL.kt
+++ b/openrndr-js/openrndr-webgl/src/webMain/kotlin/RenderTargetWebGL.kt
@@ -26,6 +26,7 @@ class ProgramRenderTargetWebGL(context: GL, override val program: Program) : Pro
     override val hasDepthBuffer = true
     override val hasStencilBuffer = true
 
+    override val blendModes: MutableList<BlendMode> = mutableListOf(BlendMode.OVER)
 }
 
 open class RenderTargetWebGL(


### PR DESCRIPTION
This fixes the circle background problem reported in #463 by adding a default blend mode of OVER to the WebGL renderer