### PR TITLE
fix: apply sRGB-to-linear conversion in WebGL clear so colors render correctly

### DIFF
--- a/openrndr-js/openrndr-webgl/src/webMain/kotlin/DriverWebGL.kt
+++ b/openrndr-js/openrndr-webgl/src/webMain/kotlin/DriverWebGL.kt
@@ -197,7 +197,8 @@ class DriverWebGL(val context: GL) : Driver {
     }
 
     override fun clear(color: ColorRGBa) {
-        context.clearColor(color.r.toFloat(), color.g.toFloat(), color.b.toFloat(), color.alpha.toFloat())
+        val lcolor = color.toLinear()
+        context.clearColor(lcolor.r.toFloat(), lcolor.g.toFloat(), lcolor.b.toFloat(), lcolor.alpha.toFloat())
         context.clearDepth(1.0f)
         context.disable(GL.SCISSOR_TEST)
         context.depthMask(true)


### PR DESCRIPTION
## Summary

WebGL sketches render clear colors correctly again. Since commit 4e119a4e switched the WebGL backend to default sRGB textures and targets, every other color path converts to linear before hitting GL, but `DriverWebGL.clear()` still passed the raw sRGB components straight to `gl.clearColor`. The background was effectively double-encoded, which is the washed-out rendering reported in #454.

## Why this matters

The reporter in #454 bisected the regression to 4e119a4e and showed side-by-side sketches where element colors and the clear color no longer match the JVM backend. The fix mirrors what the JVM driver and the WebGL draw paths already do: convert via `color.toLinear()` before `clearColor`, so the sRGB-default framebuffer encodes it back exactly once. Two lines in `openrndr-js/openrndr-webgl/src/webMain/kotlin/DriverWebGL.kt`, no API change.

## Testing

Verified the conversion matches the existing pattern used by the WebGL fill/stroke paths and the JVM driver's clear. The change is confined to the clear call; a Gradle build was not runnable in this environment (no JVM on the build host), so CI's build covers compilation.

AI was used for assistance.

Fixes #454
