### PR TITLE
[openrndr-application-sdl] Update window size fix logic to exclude Wayland

### DIFF
--- a/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
+++ b/openrndr-jvm/openrndr-application-sdl/src/main/kotlin/ApplicationSDL.kt
@@ -48,7 +48,7 @@ class Proxy<R, T>(val b: R.() -> KMutableProperty0<T>) {
 
 object ApplicationSDLConfiguration {
     val fixWindowSize by lazy {
-        Platform.type == PlatformType.WINDOWS || Platform.type == PlatformType.GENERIC
+        SDL_GetCurrentVideoDriver() != "wayland" && (Platform.type == PlatformType.WINDOWS || Platform.type == PlatformType.GENERIC)
     }
 }
 


### PR DESCRIPTION
Mouse events with Wayland display server have the correct coordinates. Therefore, no runtime fix needed.