### PR TITLE
[openrndr-draw] Defaults the contentScale of new render targets to screen scale

### DIFF
--- a/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/RenderTarget.kt
+++ b/openrndr-draw/src/commonMain/kotlin/org/openrndr/draw/RenderTarget.kt
@@ -543,7 +543,7 @@ class RenderTargetBuilder(private val renderTarget: RenderTarget) {
  *
  * @param width The width of the render target in pixels. Must be greater than 0 and less than or equal to the maximum allowed texture size.
  * @param height The height of the render target in pixels. Must be greater than 0 and less than or equal to the maximum allowed texture size.
- * @param contentScale A scaling factor to apply to the render target's content. Defaults to 1.0.
+ * @param contentScale A scaling factor to apply to the render target's content. The default of null results in the content scale being set to the active render target's content scale.
  * @param multisample Specifies the multisampling configuration for the render target. Defaults to [BufferMultisample.Disabled].
  * @param session The session to which the render target belongs. Defaults to the currently active session.
  * @param builder A builder block for additional configuration of the render target.
@@ -554,7 +554,7 @@ class RenderTargetBuilder(private val renderTarget: RenderTarget) {
 @OptIn(ExperimentalContracts::class)
 fun renderTarget(
     width: Int, height: Int,
-    contentScale: Double = 1.0,
+    contentScale: Double? = null,
     multisample: BufferMultisample = BufferMultisample.Disabled,
     session: Session? = Session.active,
     builder: RenderTargetBuilder.() -> Unit
@@ -564,10 +564,12 @@ fun renderTarget(
         callsInPlace(builder, InvocationKind.EXACTLY_ONCE)
     }
 
-    val effectiveWidth = (width * contentScale).toInt()
-    val effectiveHeight = (height * contentScale).toInt()
+    val scale = contentScale ?: RenderTarget.active.contentScale
+
+    val effectiveWidth = (width * scale).toInt()
+    val effectiveHeight = (height * scale).toInt()
     if (width <= 0 || height <= 0 || effectiveWidth > Driver.instance.properties.maxTextureSize || effectiveHeight > Driver.instance.properties.maxTextureSize) {
-        error("Unsupported render target dimensions ($width × $height @ $contentScale) maximum size: ${Driver.instance.properties.maxTextureSize}")
+        error("Unsupported render target dimensions ($width × $height @ $scale) maximum size: ${Driver.instance.properties.maxTextureSize}")
     }
 
     val effectiveMultisample = when (multisample) {
@@ -582,7 +584,7 @@ fun renderTarget(
         else -> multisample
     }
 
-    val renderTarget = Driver.instance.createRenderTarget(width, height, contentScale, effectiveMultisample, session)
+    val renderTarget = Driver.instance.createRenderTarget(width, height, scale, effectiveMultisample, session)
     RenderTargetBuilder(renderTarget).builder()
     return renderTarget
 }

--- a/openrndr-jvm/openrndr-gl3/src/commonJvmMain/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/commonJvmMain/kotlin/org/openrndr/internal/gl3/DriverGL3.kt
@@ -367,7 +367,7 @@ abstract class DriverGL3(val version: DriverVersionGL) : Driver {
 
     class Quirks {
         val clearIgnoresSRGB: Boolean by lazy {
-            val rt = renderTarget(64, 64) {
+            val rt = renderTarget(64, 64, 1.0) {
                 colorBuffer()
             }
             rt.bind()

--- a/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestColorBufferShadowGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestColorBufferShadowGL3.kt
@@ -61,7 +61,7 @@ class TestColorBufferShadowGL3 : AbstractApplicationTestFixture() {
                 cb.shadow[x, y]
             }
         }
-        val rt = renderTarget(256, 256) {
+        val rt = renderTarget(256, 256, 1.0) {
             colorBuffer(cb)
         }
         program.drawer.withTarget(rt) {

--- a/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestRenderTargetGL3.kt
+++ b/openrndr-jvm/openrndr-gl3/src/jvmTest/kotlin/TestRenderTargetGL3.kt
@@ -53,7 +53,7 @@ class TestRenderTargetGL3 : AbstractApplicationTestFixture() {
     @Test
     fun testRenderTargetCubemap() {
         val cm = cubemap(256, format = ColorFormat.RGBa)
-        val rt = renderTarget(256, 256) {
+        val rt = renderTarget(256, 256, 1.0) {
             cubemap(cm, CubemapSide.POSITIVE_X)
             depthBuffer()
         }
@@ -68,7 +68,7 @@ class TestRenderTargetGL3 : AbstractApplicationTestFixture() {
     fun testRenderTargetVolumeTexture() {
         if (Driver.glType == DriverTypeGL.GL) {
             val vt = volumeTexture(256, 256, 256)
-            val rt = renderTarget(256, 256) {
+            val rt = renderTarget(256, 256, 1.0) {
                 volumeTexture(vt, 0)
                 depthBuffer()
             }
@@ -83,7 +83,7 @@ class TestRenderTargetGL3 : AbstractApplicationTestFixture() {
     @Test
     fun testRenderTargetArrayCubemap() {
         val cm = arrayCubemap(256, 10, format = ColorFormat.RGBa)
-        val rt = renderTarget(256, 256) {
+        val rt = renderTarget(256, 256, 1.0) {
             arrayCubemap(cm, CubemapSide.POSITIVE_X, 0)
             depthBuffer()
         }

--- a/openrndr-nullgl/src/main/kotlin/DriverNullGL.kt
+++ b/openrndr-nullgl/src/main/kotlin/DriverNullGL.kt
@@ -168,7 +168,7 @@ class DriverNullGL: Driver {
     override val shaderGenerators: ShaderGenerators = ShaderGeneratorsNullGL()
 
     override val activeRenderTarget: RenderTarget
-        get() = renderTarget(640, 480) {
+        get() = renderTarget(640, 480, 1.0) {
             colorBuffer()
             depthBuffer()
         }


### PR DESCRIPTION
Ensures new render targets have a default content scale that matches the display's screen scale to avoid blurred output.