### PR TITLE
Add publication of maven snapshots to sonatype repository

### DIFF
--- a/.github/workflows/release-snapshot-to-maven-central.yml
+++ b/.github/workflows/release-snapshot-to-maven-central.yml
@@ -1,0 +1,31 @@
+name: Release snapshot to Maven Central
+on:
+#  schedule:
+#    - cron: '0 0 * * *'
+  push:
+    tags:
+      - v[0-9].[0-9]+.[0-9]+-SNAPSHOT.[0-9]+
+
+  workflow_dispatch:
+jobs:
+  release_snapshot_to_maven_central:
+    if: github.repository == 'openrndr/openrndr'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Build and publish to local maven
+        run: ./gradlew -Pskip.gl3.tests assemble snapshot
+      - name: Decode
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+      - name: Publish
+        run: |
+          ./gradlew publishAggregationToCentralSnapshots snapshot -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=openrndr -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}


### PR DESCRIPTION
This PR adds the ability to publish snapshots to the sonatype snapshot repository.